### PR TITLE
Brand update: aide lowercase + new tagline + palette fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # AIde — Claude Code Guardrails
 
+**Tagline:** "For what you're living."
+
 You are working in a 130k+ line codebase. You CANNOT hold the full system in context. Act accordingly.
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# AIde
+# aide
 
-**For what you're running.**
+**For what you're living.**
 
-AIde is a conversational web page editor. Describe what you're running — a league, a budget, a renovation — and AIde forms a living page. As things change, tell AIde. The page stays current. The URL stays the same.
+aide is a conversational web page editor. Describe what you're running — a league, a budget, a renovation — and aide forms a living page. As things change, tell aide. The page stays current. The URL stays the same.
 
 ## Stack
 

--- a/backend/services/email.py
+++ b/backend/services/email.py
@@ -30,7 +30,7 @@ async def send_magic_link(email: str, token: str) -> None:
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Sign in to AIde</title>
+        <title>Sign in to aide</title>
         <style>
             body {{
                 font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
@@ -111,12 +111,12 @@ async def send_magic_link(email: str, token: str) -> None:
     <body>
         <div class="container">
             <div class="header">
-                <h1>AIde</h1>
+                <h1>aide</h1>
             </div>
             <div class="content">
                 <p>Hello,</p>
-                <p>Click the button below to sign in to AIde. This link will expire in 15 minutes.</p>
-                <a href="{magic_link_url}" class="button">Sign in to AIde</a>
+                <p>Click the button below to sign in to aide. This link will expire in 15 minutes.</p>
+                <a href="{magic_link_url}" class="button">Sign in to aide</a>
                 <div class="fallback">
                     <p>If the button doesn't work, copy and paste this link into your browser:</p>
                     <code>{magic_link_url}</code>
@@ -132,9 +132,9 @@ async def send_magic_link(email: str, token: str) -> None:
 
     # Plain text fallback
     text_content = f"""
-    Sign in to AIde
+    Sign in to aide
 
-    Click this link to sign in to AIde:
+    Click this link to sign in to aide:
     {magic_link_url}
 
     This link will expire in 15 minutes.
@@ -146,7 +146,7 @@ async def send_magic_link(email: str, token: str) -> None:
     params = {
         "from": config.settings.EMAIL_FROM,
         "to": [email],
-        "subject": "Sign in to AIde",
+        "subject": "Sign in to aide",
         "html": html_content,
         "text": text_content,
     }

--- a/docs/eng_design/00_overview.md
+++ b/docs/eng_design/00_overview.md
@@ -10,7 +10,7 @@
 
 An aide is a living object. The user describes what they're coordinating — a graduation party, a poker league, a group trip — and AIde brings it to life as a shareable page that stays current through natural language conversation. The page is the object's body. The chat is how you talk to it. No account needed to view.
 
-The tagline: **For what you're running.**
+The tagline: **For what you're living.**
 
 ### Why Not Just a Chat?
 

--- a/docs/eng_design/specs/aide_ui_design_system_spec.md
+++ b/docs/eng_design/specs/aide_ui_design_system_spec.md
@@ -1,6 +1,6 @@
-# AIde — Design System Implementation
+# aide — Design System Implementation
 
-**Purpose:** Practical implementation reference for the AIde visual identity. This document translates the brand guidelines into code-ready specifications: CSS variables, component patterns, typography scale, and spacing system.
+**Purpose:** Practical implementation reference for the aide visual identity. This document translates the brand guidelines into code-ready specifications: CSS variables, component patterns, typography scale, and spacing system.
 
 ---
 
@@ -9,30 +9,44 @@
 ```css
 :root {
   /* ── Backgrounds ── */
-  --bg-primary: #F6F5F3;         /* Warm off-white — default page background */
-  --bg-cream: #FAFAF8;           /* Editorial cream — cards, panels, elevated surfaces */
-  --bg-white: #FFFFFF;           /* Pure white — input fields, active states */
+  --bg-primary: #F7F5F2;         /* Warm off-white — default page background */
+  --bg-secondary: #EFECEA;       /* Slightly darker — cards, panels */
+  --bg-tertiary: #E6E3DF;        /* Elevated surfaces */
+  --bg-elevated: #FFFFFF;        /* Pure white — input fields, modals */
 
   /* ── Text ── */
-  --text-primary: #1E1E1E;       /* Deep charcoal — headings, primary content */
-  --text-slate: #2A2A2A;         /* Slate black — body text, secondary headings */
-  --text-secondary: #6A6A6A;     /* Soft gray — descriptions, metadata */
-  --text-tertiary: #9A9A9A;      /* Light gray — labels, timestamps, placeholders */
-
-  /* ── Accents (use sparingly) ── */
-  --accent-navy: #1F2A44;        /* Focus states, primary buttons, active elements */
-  --accent-forest: #2F3E34;      /* Subtle emphasis, secondary accents */
-  --accent-burgundy: #5A2F3B;    /* Sparingly — errors, critical states */
-  --accent-steel: #3C506B;       /* Links, interactive elements */
+  --text-primary: #2D2D2A;       /* Warm charcoal — headings, primary content */
+  --text-secondary: #6B6963;     /* Warm gray — body text, secondary content */
+  --text-tertiary: #A8A5A0;      /* Light warm gray — labels, timestamps, placeholders */
+  --text-inverse: #F7F5F2;       /* Light text on dark backgrounds */
 
   /* ── Borders ── */
-  --border: #E0DFDC;             /* Standard borders */
-  --border-light: #EBEAE7;       /* Subtle dividers, section separators */
-  --border-focus: #1F2A44;       /* Active input borders */
+  --border-subtle: #E0DDD8;      /* Subtle dividers, section separators */
+  --border-default: #D4D1CC;     /* Standard borders */
+  --border-strong: #A8A5A0;      /* Active input borders, emphasis */
+
+  /* ── Sage Accent Scale ── */
+  --sage-50: #F0F3ED;
+  --sage-100: #DDE4D7;
+  --sage-200: #C2CCB8;
+  --sage-300: #A3B394;
+  --sage-400: #8B9E7C;
+  --sage-500: #7C8C6E;           /* Primary accent */
+  --sage-600: #667358;
+  --sage-700: #515C46;
+  --sage-800: #3C4534;
+  --sage-900: #282E23;
+
+  /* ── Accent Aliases ── */
+  --accent: var(--sage-500);
+  --accent-hover: var(--sage-600);
+  --accent-subtle: var(--sage-50);
+  --accent-muted: var(--sage-100);
 
   /* ── Typography ── */
-  --font-serif: 'Cormorant Garamond', Georgia, 'Times New Roman', serif;
-  --font-sans: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-serif: 'Playfair Display', Georgia, serif;
+  --font-heading: 'Instrument Sans', -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-sans: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 
   /* ── Spacing Scale (8px base) ── */
   --space-1: 4px;
@@ -50,14 +64,45 @@
   --space-32: 128px;
 
   /* ── Radius ── */
-  --radius-sm: 3px;
-  --radius-md: 5px;
-  --radius-lg: 8px;
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 16px;
+  --radius-full: 999px;
 
   /* ── Transitions ── */
   --transition-fast: 150ms ease;
   --transition-normal: 200ms ease;
   --transition-slow: 250ms ease;
+
+  /* ── Backward Compatibility ── */
+  --border-light: var(--border-subtle);
+}
+```
+
+### Dark Mode
+
+```css
+.dark, [data-theme="dark"] {
+  --bg-primary: #1E1E1C;
+  --bg-secondary: #262624;
+  --bg-tertiary: #2E2E2B;
+  --bg-elevated: #333330;
+
+  --text-primary: #E8E6E1;
+  --text-secondary: #A8A5A0;
+  --text-tertiary: #6B6963;
+  --text-inverse: #1E1E1C;
+
+  --border-subtle: #333330;
+  --border-default: #3D3D39;
+  --border-strong: #5A5850;
+
+  --accent: var(--sage-400);      /* Lighter in dark mode */
+  --accent-hover: var(--sage-300);
+  --accent-subtle: #2A2E27;
+  --accent-muted: #333829;
+
+  --border-light: var(--border-subtle);
 }
 ```
 
@@ -70,22 +115,22 @@
 ```html
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=IBM+Plex+Sans:wght@300;400;500&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;500;600;700&family=Instrument+Sans:wght@400;500;600;700&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500;9..40,600&display=swap" rel="stylesheet">
 ```
 
 ### Type Scale
 
 | Level | Font | Size | Weight | Line Height | Letter Spacing | Use |
 |---|---|---|---|---|---|---|
-| Display | Serif | 48–64px | 400 | 1.12 | -0.01em | Hero headlines |
-| H1 | Serif | 36–42px | 400 | 1.2 | -0.005em | Page titles |
-| H2 | Serif | 28–32px | 400 | 1.25 | 0 | Section headings |
-| H3 | Sans | 18–20px | 500 | 1.4 | 0 | Subsection headings |
-| Body | Sans | 16px | 300 or 400 | 1.65 | 0 | Paragraphs, descriptions |
-| Body Small | Sans | 15px | 400 | 1.55 | 0 | State entries, secondary content |
-| UI Label | Sans | 13–14px | 500 | 1.4 | 0.02em | Buttons, navigation, field labels |
-| Caption | Sans | 12px | 400 | 1.4 | 0.01em | Timestamps, metadata |
-| Overline | Sans | 11px | 500 | 1.3 | 0.12em | Section labels (uppercase) |
+| Display | Serif (Playfair) | 48–64px | 700 | 1.12 | -0.01em | Hero headlines |
+| H1 | Serif (Playfair) | 36–42px | 700 | 1.2 | -0.005em | Page titles |
+| H2 | Serif (Playfair) | 28–32px | 700 | 1.25 | 0 | Section headings |
+| H3 | Heading (Instrument Sans) | 18–20px | 600 | 1.4 | 0 | Subsection headings |
+| Body | Sans (DM Sans) | 16px | 400 | 1.65 | 0 | Paragraphs, descriptions |
+| Body Small | Sans (DM Sans) | 15px | 400 | 1.55 | 0 | State entries, secondary content |
+| UI Label | Sans (DM Sans) | 13–14px | 500 | 1.4 | 0.02em | Buttons, navigation, field labels |
+| Caption | Sans (DM Sans) | 12px | 400 | 1.4 | 0.01em | Timestamps, metadata |
+| Overline | Sans (DM Sans) | 11px | 600 | 1.3 | 0.12em | Section labels (uppercase) |
 
 ### CSS Implementation
 
@@ -94,7 +139,7 @@
 .text-display {
   font-family: var(--font-serif);
   font-size: clamp(42px, 6vw, 64px);
-  font-weight: 400;
+  font-weight: 700;
   line-height: 1.12;
   letter-spacing: -0.01em;
   color: var(--text-primary);
@@ -104,7 +149,7 @@
 .text-h1 {
   font-family: var(--font-serif);
   font-size: clamp(32px, 4.5vw, 42px);
-  font-weight: 400;
+  font-weight: 700;
   line-height: 1.2;
   color: var(--text-primary);
 }
@@ -113,16 +158,16 @@
 .text-h2 {
   font-family: var(--font-serif);
   font-size: clamp(24px, 3.5vw, 32px);
-  font-weight: 400;
+  font-weight: 700;
   line-height: 1.25;
   color: var(--text-primary);
 }
 
 /* H3 */
 .text-h3 {
-  font-family: var(--font-sans);
+  font-family: var(--font-heading);
   font-size: 18px;
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1.4;
   color: var(--text-primary);
 }
@@ -131,7 +176,7 @@
 .text-body {
   font-family: var(--font-sans);
   font-size: 16px;
-  font-weight: 300;
+  font-weight: 400;
   line-height: 1.65;
   color: var(--text-secondary);
 }
@@ -140,7 +185,7 @@
 .text-overline {
   font-family: var(--font-sans);
   font-size: 11px;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--text-tertiary);
@@ -161,9 +206,9 @@
   font-size: 14px;
   font-weight: 500;
   letter-spacing: 0.02em;
-  color: var(--bg-primary);
+  color: var(--text-inverse);
   background: var(--text-primary);
-  padding: 13px 28px;
+  padding: 12px 24px;
   border: none;
   border-radius: var(--radius-md);
   cursor: pointer;
@@ -172,22 +217,44 @@
 }
 
 .btn-primary:hover {
-  background: var(--accent-navy);
+  background: var(--sage-700);
 }
 ```
 
 CTA copy: "Start something."
 No gradients. No heavy shadows. No pill shapes.
 
-**Secondary / Text Button**
+**Secondary Button**
 ```css
 .btn-secondary {
   display: inline-block;
   font-family: var(--font-sans);
   font-size: 14px;
+  font-weight: 500;
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-default);
+  padding: 12px 24px;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  text-decoration: none;
+}
+
+.btn-secondary:hover {
+  background: var(--bg-tertiary);
+}
+```
+
+**Ghost Button**
+```css
+.btn-ghost {
+  display: inline-block;
+  font-family: var(--font-sans);
+  font-size: 14px;
   font-weight: 400;
   color: var(--text-secondary);
-  background: none;
+  background: transparent;
   border: none;
   padding: 8px 0;
   cursor: pointer;
@@ -195,7 +262,7 @@ No gradients. No heavy shadows. No pill shapes.
   text-decoration: none;
 }
 
-.btn-secondary:hover {
+.btn-ghost:hover {
   color: var(--text-primary);
 }
 ```
@@ -208,13 +275,13 @@ No gradients. No heavy shadows. No pill shapes.
   font-size: 15px;
   font-weight: 400;
   color: var(--text-primary);
-  background: var(--bg-white);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  padding: 10px 14px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  padding: 12px 16px;
   width: 100%;
   outline: none;
-  transition: border-color var(--transition-fast);
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
 }
 
 .input::placeholder {
@@ -222,27 +289,24 @@ No gradients. No heavy shadows. No pill shapes.
 }
 
 .input:focus {
-  border-color: var(--border-focus);
-  border-bottom-width: 2px;
-  padding-bottom: 9px; /* compensate for border width */
+  border-color: var(--sage-500);
+  box-shadow: 0 0 0 3px var(--sage-50);
 }
 ```
-
-No glowing focus theatrics. Accent underline on active.
 
 ### Cards / Panels
 
 ```css
 .panel {
-  background: var(--bg-cream);
-  border: 1px solid var(--border-light);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-subtle);
   border-radius: var(--radius-md);
   overflow: hidden;
 }
 
 .panel-header {
   padding: var(--space-4) var(--space-6);
-  border-bottom: 1px solid var(--border-light);
+  border-bottom: 1px solid var(--border-subtle);
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -250,6 +314,26 @@ No glowing focus theatrics. Accent underline on active.
 
 .panel-body {
   padding: var(--space-6);
+}
+```
+
+### Tags / Badges
+
+```css
+.tag-sage {
+  display: inline-block;
+  font-family: var(--font-sans);
+  font-size: 12px;
+  font-weight: 500;
+  padding: 4px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--sage-50);
+  color: var(--sage-600);
+}
+
+.tag-neutral {
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
 }
 ```
 
@@ -261,7 +345,7 @@ No glowing focus theatrics. Accent underline on active.
 }
 
 .state-entry + .state-entry {
-  border-top: 1px solid var(--border-light);
+  border-top: 1px solid var(--border-subtle);
 }
 
 .state-entry-date {
@@ -289,13 +373,13 @@ No glowing focus theatrics. Accent underline on active.
   color: var(--text-tertiary);
 }
 
-/* Active / current state — subtle dot */
+/* Active / current state — subtle sage dot */
 .status--active::before {
   content: '';
   display: inline-block;
   width: 6px;
   height: 6px;
-  background: var(--accent-forest);
+  background: var(--sage-500);
   border-radius: 50%;
   margin-right: 6px;
   vertical-align: middle;
@@ -330,7 +414,7 @@ All motion communicates state change, then returns to stillness.
 /* Highlight pulse — for updated fields */
 @keyframes highlightPulse {
   0% { background-color: transparent; }
-  20% { background-color: rgba(31, 42, 68, 0.06); }
+  20% { background-color: var(--sage-50); }
   100% { background-color: transparent; }
 }
 
@@ -421,14 +505,51 @@ Use CSS Grid sparingly. Prefer single-column layouts for content. Grid for use-c
 
 ---
 
-## 6. Accessibility
+## 6. Icons
+
+Use Tabler Icons with `stroke-width="1.0"` (thinner than default 1.5).
+
+### CDN
+
+```html
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@latest/tabler-icons.min.css">
+```
+
+### Inline SVG pattern (preferred)
+
+```html
+<svg width="20" height="20" viewBox="0 0 24 24"
+  fill="none" stroke="currentColor"
+  stroke-width="1.0" stroke-linecap="round" stroke-linejoin="round">
+  <!-- path data from Tabler -->
+</svg>
+```
+
+### Key icon mapping
+
+| Use | Tabler Icon |
+|-----|-------------|
+| Home | `icon-home` |
+| Dashboard | `icon-layout-dashboard` |
+| Settings | `icon-settings` |
+| Edit | `icon-pencil` |
+| Publish | `icon-world-upload` |
+| New aide | `icon-plus` |
+| Chat / AI | `icon-message-circle` |
+| Delete | `icon-trash` |
+| Copy | `icon-copy` |
+| Check | `icon-check` |
+
+---
+
+## 7. Accessibility
 
 | Requirement | Standard |
 |---|---|
 | Contrast ratio | WCAG AA minimum (4.5:1 normal text, 3:1 large text) |
 | Font size minimum | 13px (labels), 15px (body content) |
 | Line height | 1.5+ for body text |
-| Focus states | Visible, uses `--border-focus` color |
+| Focus states | Visible, uses sage-500 with subtle box-shadow |
 | Touch targets | 44px minimum on mobile |
 | Reduced motion | Respect `prefers-reduced-motion` |
 
@@ -436,15 +557,43 @@ Use CSS Grid sparingly. Prefer single-column layouts for content. Grid for use-c
 
 | Pair | Ratio | Pass |
 |---|---|---|
-| --text-primary on --bg-primary | 13.5:1 | AA |
-| --text-secondary on --bg-primary | 5.1:1 | AA |
-| --text-tertiary on --bg-primary | 3.2:1 | AA Large only |
-| --text-primary on --bg-cream | 13.2:1 | AA |
-| --bg-primary on --text-primary | 13.5:1 | AA (reversed, for buttons) |
+| --text-primary on --bg-primary | 12.1:1 | AA |
+| --text-secondary on --bg-primary | 5.3:1 | AA |
+| --text-tertiary on --bg-primary | 3.4:1 | AA Large only |
+| --text-primary on --bg-secondary | 11.8:1 | AA |
+| --text-inverse on --text-primary | 12.1:1 | AA (reversed, for buttons) |
 
 ---
 
-## 7. Design Litmus Test
+## 8. Wordmark
+
+The aide wordmark uses lowercase "aide" in Playfair Display 700 with a sage thin underline on "ai":
+
+```html
+<span class="wordmark">
+  <span class="wordmark-ai">ai</span>de
+</span>
+```
+
+```css
+.wordmark {
+  font-family: var(--font-serif);
+  font-weight: 700;
+}
+
+.wordmark-ai {
+  text-decoration: underline;
+  text-decoration-color: var(--sage-500);
+  text-underline-offset: 3px;
+  text-decoration-thickness: 1px;
+}
+```
+
+**Note:** The underline is for the wordmark/logo only. In body text, "aide" is written plain lowercase with no underline.
+
+---
+
+## 9. Design Litmus Test
 
 Before shipping any component, screen, or interaction:
 
@@ -466,6 +615,6 @@ Or does it feel like software trying to impress?
 - [ ] No mascots or illustrations
 - [ ] Generous white space
 - [ ] Strong typographic hierarchy
-- [ ] Muted, neutral color palette
+- [ ] Muted, neutral color palette with sage accents
 - [ ] Subtle, purposeful motion only
 - [ ] Publication feel, not SaaS feel

--- a/docs/program_management/aide_launch_plan.md
+++ b/docs/program_management/aide_launch_plan.md
@@ -193,7 +193,7 @@ _Let people give you money._
 _The thing people see before they sign up._
 
 ### 4.1 Landing Page (toaide.com)
-- [ ] Hero: "For what you're running." + one-line explainer
+- [ ] Hero: "For what you're living." + one-line explainer
 - [ ] Demo: auto-playing conversation → live page building
 - [ ] Use cases: 3-4 examples with screenshots (poker league, wedding, grocery list, trip)
 - [ ] Signal angle: "Update your page from a text message"

--- a/docs/refactors/aide_brand_update_plan.md
+++ b/docs/refactors/aide_brand_update_plan.md
@@ -1,0 +1,234 @@
+# aide — Brand Update Plan
+
+**Based on:** `zcancio/aide` repo at commit `b1222fe`
+**Date:** 2026-02-21
+
+---
+
+## Current State
+
+The new brand system (Playfair Display + Instrument Sans + DM Sans, warm grayscale + sage palette) has been **partially applied**. The core rendering pipeline is updated, but documentation, supporting files, and a few code files still carry the old brand.
+
+### ✅ Already Updated
+
+| File | Status |
+|------|--------|
+| `engine/engine.min.js` | New fonts, sage palette, new vars |
+| `engine/builds/engine.compact.js` | Matches engine.min.js |
+| `engine/builds/engine.py` | New brand CSS (2788 lines) |
+| `engine/kernel/react_preview.py` | Playfair + DM Sans, new palette, `--border-light` alias |
+| `frontend/index.html` | New font loading, new palette for editor shell, new CSS vars for rendered pages |
+| `engine/SKILL.md` | Playfair Display, DM Sans references |
+| `skills/aide-builder/SKILL.md` | Correct font references |
+| `skills/aide-builder/examples/poker-league.html` | New brand CSS |
+
+### ❌ Needs Updating
+
+Organized by priority and effort.
+
+---
+
+## Tier 1 — User-Facing / Shipped Code (do first)
+
+### 1. `backend/services/email.py` — Magic link email template
+
+**What's wrong:** "AIde" (mixed case) in 6 places — email subject, heading, body text. Should be lowercase "aide" per wordmark rules.
+
+**Changes:**
+- Line 33: `<title>Sign in to AIde</title>` → `<title>Sign in to aide</title>`
+- Line 114: `<h1>AIde</h1>` → `<h1>aide</h1>`
+- Line 118: `sign in to AIde` → `sign in to aide`
+- Line 119: `Sign in to AIde` → `Sign in to aide`
+- Line 135: `Sign in to AIde` → `Sign in to aide`
+- Line 137: `sign in to AIde` → `sign in to aide`
+- Line 149: `"subject": "Sign in to AIde"` → `"subject": "Sign in to aide"`
+- Consider updating the email's visual design to use DM Sans and the sage palette (currently generic system font + black header)
+
+**Effort:** Small (~15 min)
+
+### 2. `frontend/flight-recorder.html` — Flight recorder UI
+
+**What's wrong:** 9 references to old colors (`#e2e8f0`, `#2d3748`). This is a React-in-HTML file (1313 lines) used for session replay/debugging.
+
+**Changes (inline JS styles):**
+- `#e2e8f0` → `#E0DDD8` (border-subtle) — 7 occurrences
+- `#2d3748` → `#2D2D2A` (text-primary) — 1 occurrence
+- `#64748b` → `#6B6963` (text-secondary) if present
+- Body background if using `#fafaf9` → `#F7F5F2`
+
+**Effort:** Medium (~30 min, careful with JSX inline styles)
+
+### 3. `README.md` — Public repo face
+
+**What's wrong:** "AIde" mixed case in heading, old tagline "For what you're running."
+
+**Changes:**
+- `# AIde` → `# aide`
+- `**For what you're running.**` → `**For what you're living.**`
+- "AIde" in body text → "aide" (4 instances)
+
+**Effort:** Small (~10 min)
+
+---
+
+## Tier 2 — Active Documentation (referenced by Claude Code)
+
+### 4. `docs/eng_design/specs/aide_ui_design_system_spec.md` — **Full rewrite needed**
+
+**What's wrong:** This is the canonical design system spec and it's completely stale. It has:
+- Cormorant Garamond + IBM Plex Sans
+- Old accent vars (navy, forest, burgundy, steel)
+- Old palette (#F6F5F3 bg, #1E1E1E text — close but not matching the finalized brand)
+- Old radius values (3/5/8)
+- No dark mode
+- No sage scale
+- No `--font-heading` variable
+
+**What to do:** Rewrite the entire CSS Custom Properties section and all component specs to match the finalized brand from `design_update_instructions.md`. This is the file Claude Code reads to understand the design system, so accuracy matters.
+
+**Effort:** Large (~1–2 hours, but critical)
+
+### 5. `CLAUDE.md` — Claude Code instructions
+
+**What's wrong:** No explicit tagline line. Title says `# AIde — Claude Code Guardrails`. The name "AIde" is used throughout in code-identifier context which is fine for class names/variables, but the title of the doc itself is display text.
+
+**Changes:**
+- Check if a tagline line should be added (the project-level CLAUDE.md in this claude.ai project has `**Tagline:** "For what you're running."`)
+- The repo CLAUDE.md doesn't have a tagline field at all — consider adding `**Tagline:** "For what you're living."` near the top
+
+**Effort:** Small (~10 min)
+
+### 6. `docs/eng_design/00_overview.md` — Overview doc
+
+**What's wrong:** Line 13: `The tagline: **For what you're running.**`
+
+**Changes:** → `The tagline: **For what you're living.**`
+
+**Effort:** Trivial
+
+---
+
+## Tier 3 — Strategy & Planning Docs
+
+### 7. `docs/prds/aide_prd.md`
+
+**What's wrong:** "what you're running" appears as product description throughout. This is tricky — "running" is used conceptually (you "run" a league, a budget), not just as the tagline.
+
+**Recommendation:** Only update the explicit tagline instance if it appears verbatim. Leave conceptual uses of "running" — they describe user activity, not the tagline. The PRD is a historical document.
+
+**Effort:** Small (~10 min)
+
+### 8. `docs/program_management/aide_launch_plan.md`
+
+**What's wrong:** Line 196: `Hero: "For what you're running."` — this is in the landing page task.
+
+**Changes:** → `Hero: "For what you're living."`
+
+**Effort:** Trivial
+
+### 9. `docs/strategy/aide_engine_distribution.md`
+
+**What's wrong:** Line 218: `"description": "Build and maintain living pages for what you're running."`
+
+**Changes:** → `"Build and maintain living pages for what you're living."`
+
+**Effort:** Trivial
+
+### 10. `docs/strategy/aide_living_objects.md`
+
+**What's wrong:** "what you're running" in ~4 places, used as conceptual description.
+
+**Recommendation:** Leave as-is. This is a strategy doc describing the concept. The phrase "what you're running" is used descriptively, not as the tagline. Updating it would change the meaning.
+
+**Effort:** Skip
+
+---
+
+## Tier 4 — Test Data (handle carefully)
+
+### 11. Engine test files — Old color values as test data
+
+**Files affected:**
+- `engine/kernel/tests/tests_reducer/test_reducer_walkthrough.py`
+- `engine/kernel/tests/tests_reducer/test_reducer_v2_golden.py`
+- `engine/kernel/tests/tests_reducer/test_reducer_determinism.py`
+- `engine/kernel/tests/tests_reducer/test_reducer_v2_style_meta_signals.py`
+- `engine/kernel/tests/tests_reducer/test_reducer_round_trip.py`
+- `engine/kernel/tests/tests_reducer/test_reducer_idempotency.py`
+
+**What's there:** `#2d3748` and `#fafaf9` used as test input values for `style.set` payloads and assertions. Also `"IBM Plex Sans"` in one walkthrough test.
+
+**Recommendation:** Update test values to new brand colors (`#2D2D2A`, `#F7F5F2`, `DM Sans`) so they don't suggest the old brand to anyone reading the tests. But these are arbitrary color values in test data — they don't affect rendering. **Run tests after changing to ensure nothing breaks.**
+
+**Effort:** Medium (~30 min, must run full test suite)
+
+### 12. `scripts/eval_0a.py`
+
+**What's wrong:** Line 166: Default style suggestion uses `#2d3748`.
+
+**Changes:** → `#2D2D2A`
+
+**Effort:** Trivial
+
+---
+
+## Tier 5 — Archive (leave alone)
+
+### 13. `docs/archive/v1.3_eng_design/specs/*`
+
+Old renderer and primitive specs reference Cormorant Garamond. These are explicitly archived. **Do not update.**
+
+### 14. `docs/refactors/brand_design_update_instructions.md`
+
+This is the instructions document itself — it contains old values by design (as "find this → replace with that"). **Do not update.**
+
+---
+
+## Compatibility Note: `--border-light` Alias
+
+The updated engine files use `--border-light: var(--border-subtle)` as a backward-compatibility alias. This is intentional and correct — it lets CSS that still references `border-light` work while the canonical variable is now `border-subtle`. The same pattern is used in `react_preview.py`, `engine.min.js`, `engine.compact.js`, and `frontend/index.html`.
+
+**Do not remove these aliases** until all references to `--border-light` are cleaned up.
+
+---
+
+## Execution Order
+
+```
+1. backend/services/email.py          (user-facing, quick win)
+2. README.md                          (public-facing, quick win)
+3. CLAUDE.md                          (add tagline)
+4. docs/eng_design/00_overview.md     (tagline fix)
+5. docs/program_management/aide_launch_plan.md  (tagline fix)
+6. docs/strategy/aide_engine_distribution.md    (tagline fix)
+7. frontend/flight-recorder.html      (old colors → new)
+8. scripts/eval_0a.py                 (old color → new)
+9. engine/kernel/tests/**             (test data colors → new, run tests)
+10. docs/eng_design/specs/aide_ui_design_system_spec.md  (full rewrite — biggest item)
+```
+
+**Estimated total effort:** 3–4 hours
+
+---
+
+## Validation After All Changes
+
+```bash
+# No old fonts anywhere in non-archive, non-instructions code
+grep -rn "Cormorant\|IBM Plex" --include="*.py" --include="*.ts" --include="*.js" --include="*.html" --include="*.css" \
+  | grep -v docs/archive | grep -v docs/refactors/brand_design | grep -v node_modules
+
+# No old colors in non-archive, non-instructions, non-test code
+grep -rn "#fafaf9\|#2d3748\|#4a5568\|#a0aec0" --include="*.py" --include="*.ts" --include="*.js" --include="*.html" \
+  | grep -v docs/archive | grep -v docs/refactors/brand_design | grep -v node_modules
+
+# No old accent vars
+grep -rn "accent-steel\|accent-navy\|accent-forest\|accent-burgundy" --include="*.py" --include="*.ts" --include="*.js" --include="*.html" \
+  | grep -v docs/archive | grep -v docs/refactors/brand_design | grep -v node_modules
+
+# Old tagline only in non-tagline contexts
+grep -rn "what you're running" --include="*.md" | grep -v docs/archive | grep -v docs/refactors/brand_design
+
+# Tests still pass
+pytest engine/kernel/tests/ -x
+```

--- a/docs/strategy/aide_engine_distribution.md
+++ b/docs/strategy/aide_engine_distribution.md
@@ -215,7 +215,7 @@ aide-plugin/
 │       {
 │         "name": "aide",
 │         "version": "1.0.0",
-│         "description": "Build and maintain living pages for what you're running.",
+│         "description": "Build and maintain living pages for what you're living.",
 │         "author": "Bantay LLC"
 │       }
 ├── .mcp.json                 ← connects to toaide.com/mcp

--- a/engine/kernel/tests/fixtures/golden/create_football_squares.jsonl
+++ b/engine/kernel/tests/fixtures/golden/create_football_squares.jsonl
@@ -9,5 +9,5 @@
 {"t":"entity.create","id":"participants_list","parent":"participants_section","display":"table","p":{"headers":["Name","Squares Owned","Amount Paid","Status"]}}
 {"t":"entity.create","id":"rules_section","parent":"page","display":"section","p":{"title":"Rules & Payouts","collapsed":true}}
 {"t":"entity.create","id":"rules_text","parent":"rules_section","display":"text","p":{"content":"Standard squares pool rules: numbers drawn randomly after all squares sold. Payouts typically 20% each quarter (1st, 2nd, 3rd) and 40% final score. Winners determined by last digit of each team's score at end of each quarter."}}
-{"t":"style.set","p":{"primary_color":"#2d3748","font_family":"Inter","density":"comfortable"}}
+{"t":"style.set","p":{"primary_color":"#2D2D2A","font_family":"Inter","density":"comfortable"}}
 {"t":"voice","text":"Squares pool ready. Add participants as they buy squares."}

--- a/engine/kernel/tests/fixtures/golden/create_graduation.jsonl
+++ b/engine/kernel/tests/fixtures/golden/create_graduation.jsonl
@@ -19,5 +19,5 @@
 {"t":"entity.create","id":"task_invites","parent":"tasks","display":"card","p":{"task":"Send invitations","done":false}}
 {"t":"entity.create","id":"task_lodging","parent":"tasks","display":"card","p":{"task":"Reserve hotel blocks","done":false}}
 {"t":"entity.create","id":"task_decorations","parent":"tasks","display":"card","p":{"task":"Plan decorations","done":false}}
-{"t":"style.set","p":{"primary_color":"#2d3748","font_family":"Inter","density":"comfortable"}}
+{"t":"style.set","p":{"primary_color":"#2D2D2A","font_family":"Inter","density":"comfortable"}}
 {"t":"voice","text":"Graduation party page ready. Add guests and food items to start coordinating."}

--- a/engine/kernel/tests/fixtures/golden/create_group_trip.jsonl
+++ b/engine/kernel/tests/fixtures/golden/create_group_trip.jsonl
@@ -1,6 +1,6 @@
 {"t":"meta.set","p":{"title":"Cabo Trip - March 15-20","identity":"group_trip_planner"}}
 {"t":"entity.create","id":"page","display":"page","p":{}}
-{"t":"style.set","p":{"primary_color":"#2d3748","font_family":"Inter","density":"comfortable"}}
+{"t":"style.set","p":{"primary_color":"#2D2D2A","font_family":"Inter","density":"comfortable"}}
 {"t":"entity.create","id":"trip_overview","parent":"page","display":"card","p":{"destination":"Cabo","dates":"March 15-20, 2025","group_size":8,"budget_per_person":1500,"total_budget":12000}}
 {"t":"entity.create","id":"friends_section","parent":"page","display":"section","p":{"title":"Friends"}}
 {"t":"entity.create","id":"friends_list","parent":"friends_section","display":"table","p":{}}

--- a/engine/kernel/tests/fixtures/golden/create_poker.jsonl
+++ b/engine/kernel/tests/fixtures/golden/create_poker.jsonl
@@ -16,5 +16,5 @@
 {"t":"entity.create","id":"rotation_section","parent":"poker_league","display":"section","p":{"title":"Rotation"}}
 {"t":"entity.create","id":"host_rotation","parent":"rotation_section","display":"list","p":{"title":"Host Order","items":["Alex","Blake","Casey","Devon","Ellis","Finley","Gray","Harper"]}}
 {"t":"entity.create","id":"snack_rotation","parent":"rotation_section","display":"list","p":{"title":"Snack Order","items":["Alex","Blake","Casey","Devon","Ellis","Finley","Gray","Harper"]}}
-{"t":"style.set","p":{"primary_color":"#2d3748","font_family":"Inter","density":"comfortable"}}
+{"t":"style.set","p":{"primary_color":"#2D2D2A","font_family":"Inter","density":"comfortable"}}
 {"t":"voice","text":"Poker league ready. Set the first host to lock in Jan 23."}

--- a/engine/kernel/tests/tests_reducer/test_reducer_determinism.py
+++ b/engine/kernel/tests/tests_reducer/test_reducer_determinism.py
@@ -356,10 +356,10 @@ def poker_league_events():
     e(
         "style.set",
         {
-            "primary_color": "#2d3748",
+            "primary_color": "#2D2D2A",
             "font_family": "Inter",
             "density": "comfortable",
-            "bg_color": "#fafaf9",
+            "bg_color": "#F7F5F2",
         },
     )
 

--- a/engine/kernel/tests/tests_reducer/test_reducer_idempotency.py
+++ b/engine/kernel/tests/tests_reducer/test_reducer_idempotency.py
@@ -139,7 +139,7 @@ def grocery_state(empty):
     apply(
         "style.set",
         {
-            "primary_color": "#2d3748",
+            "primary_color": "#2D2D2A",
             "font_family": "Inter",
         },
     )
@@ -618,7 +618,7 @@ class TestStyleSetIdempotent:
             make_event(
                 seq=seq + 1,
                 type="style.set",
-                payload={"primary_color": "#2d3748", "font_family": "Inter"},
+                payload={"primary_color": "#2D2D2A", "font_family": "Inter"},
             ),
         )
         assert result.applied
@@ -634,7 +634,7 @@ class TestStyleSetIdempotent:
             make_event(
                 seq=seq + 1,
                 type="style.set",
-                payload={"primary_color": "#2d3748", "font_family": "Inter"},
+                payload={"primary_color": "#2D2D2A", "font_family": "Inter"},
             ),
         )
 
@@ -651,13 +651,13 @@ class TestStyleSetIdempotent:
                 seq=seq + 1,
                 type="style.set",
                 payload={
-                    "primary_color": "#2d3748",  # Same
+                    "primary_color": "#2D2D2A",  # Same
                     "density": "compact",  # New
                 },
             ),
         )
         assert result.applied
-        assert result.snapshot["styles"]["primary_color"] == "#2d3748"
+        assert result.snapshot["styles"]["primary_color"] == "#2D2D2A"
         assert result.snapshot["styles"]["font_family"] == "Inter"  # Preserved
         assert result.snapshot["styles"]["density"] == "compact"  # Added
 

--- a/engine/kernel/tests/tests_reducer/test_reducer_round_trip.py
+++ b/engine/kernel/tests/tests_reducer/test_reducer_round_trip.py
@@ -269,7 +269,7 @@ def poker_league_events():
     e(
         "style.set",
         {
-            "primary_color": "#2d3748",
+            "primary_color": "#2D2D2A",
             "font_family": "Inter",
             "density": "comfortable",
         },
@@ -696,7 +696,7 @@ class TestFullSnapshotRoundTrip:
         assert root_children == ["block_title", "block_metric", "block_roster", "block_schedule"]
 
         # Styles
-        assert restored["styles"]["primary_color"] == "#2d3748"
+        assert restored["styles"]["primary_color"] == "#2D2D2A"
 
         # Meta
         assert restored["meta"]["title"] == "Poker League — Spring 2026"

--- a/engine/kernel/tests/tests_reducer/test_reducer_v2_golden.py
+++ b/engine/kernel/tests/tests_reducer/test_reducer_v2_golden.py
@@ -184,7 +184,7 @@ class TestCreateGraduationGolden:
     def test_graduation_sets_styles(self):
         events = load_golden_file("create_graduation.jsonl")
         snapshot = replay(events)
-        assert snapshot["styles"]["global"]["primary_color"] == "#2d3748"
+        assert snapshot["styles"]["global"]["primary_color"] == "#2D2D2A"
         assert snapshot["styles"]["global"]["font_family"] == "Inter"
         assert snapshot["styles"]["global"]["density"] == "comfortable"
 

--- a/engine/kernel/tests/tests_reducer/test_reducer_v2_style_meta_signals.py
+++ b/engine/kernel/tests/tests_reducer/test_reducer_v2_style_meta_signals.py
@@ -35,11 +35,11 @@ class TestStyleSet:
     def test_sets_global_styles(self, empty):
         result = reduce(
             empty,
-            {"t": "style.set", "p": {"primary_color": "#2d3748", "font_family": "Inter", "density": "comfortable"}},
+            {"t": "style.set", "p": {"primary_color": "#2D2D2A", "font_family": "Inter", "density": "comfortable"}},
         )
         assert result.accepted
         styles = result.snapshot["styles"]["global"]
-        assert styles["primary_color"] == "#2d3748"
+        assert styles["primary_color"] == "#2D2D2A"
         assert styles["font_family"] == "Inter"
         assert styles["density"] == "comfortable"
 

--- a/engine/kernel/tests/tests_reducer/test_reducer_walkthrough.py
+++ b/engine/kernel/tests/tests_reducer/test_reducer_walkthrough.py
@@ -546,7 +546,7 @@ class TestPokerLeagueWalkthrough:
         step(
             "style.set",
             {
-                "primary_color": "#2d3748",
+                "primary_color": "#2D2D2A",
                 "font_family": "Inter",
                 "density": "comfortable",
             },
@@ -605,7 +605,7 @@ class TestPokerLeagueWalkthrough:
         assert root_children == ["block_title", "block_next", "block_roster", "block_schedule"]
 
         # Styles
-        assert snapshot["styles"]["primary_color"] == "#2d3748"
+        assert snapshot["styles"]["primary_color"] == "#2D2D2A"
 
         # Meta
         assert snapshot["meta"]["title"] == "Poker League — Spring 2026"
@@ -970,7 +970,7 @@ class TestBudgetTrackerWalkthrough:
             "style.set",
             {
                 "primary_color": "#1a365d",
-                "font_family": "IBM Plex Sans",
+                "font_family": "DM Sans",
             },
         )
 

--- a/frontend/flight-recorder.html
+++ b/frontend/flight-recorder.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Flight Recorder - AIde</title>
+  <title>Flight Recorder - aide</title>
   <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
@@ -12,7 +12,7 @@
     body {
       font-family: system-ui, -apple-system, sans-serif;
       background: #0f0f17;
-      color: #e2e8f0;
+      color: #E0DDD8;
       overflow: hidden;
     }
     #root { height: 100vh; width: 100vw; }
@@ -105,11 +105,11 @@
               padding: "10px 14px",
               borderRadius: isUser ? "14px 14px 4px 14px" : "14px 14px 14px 4px",
               background: isUser ? "#1a1a2e" : "#ffffff",
-              color: isUser ? "#e2e8f0" : "#2d3748",
+              color: isUser ? "#E0DDD8" : "#2D2D2A",
               fontSize: 14,
               lineHeight: 1.5,
               fontFamily: "system-ui, -apple-system, sans-serif",
-              border: isUser ? "none" : "1px solid #e2e8f0",
+              border: isUser ? "none" : "1px solid #E0DDD8",
               whiteSpace: "pre-wrap",
             }}
           >
@@ -314,7 +314,7 @@
             display: "flex",
             flexDirection: "column",
             background: "#0f0f17",
-            color: "#e2e8f0",
+            color: "#E0DDD8",
             fontFamily: "system-ui, -apple-system, sans-serif",
             overflow: "hidden",
           }}
@@ -664,7 +664,7 @@
                 style={{
                   padding: "8px 16px",
                   background: "#f8fafc",
-                  borderBottom: "1px solid #e2e8f0",
+                  borderBottom: "1px solid #E0DDD8",
                   display: "flex",
                   alignItems: "center",
                   justifyContent: "space-between",
@@ -686,7 +686,7 @@
               </div>
               <iframe
                 ref={iframeRef}
-                title="AIde Preview"
+                title="aide Preview"
                 style={{
                   flex: 1,
                   border: "none",
@@ -741,7 +741,7 @@
                   }}
                 >
                   <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
-                    <span style={{ fontSize: 14, fontWeight: 600, color: "#e2e8f0" }}>
+                    <span style={{ fontSize: 14, fontWeight: 600, color: "#E0DDD8" }}>
                       Replay Comparison
                     </span>
                     <span style={{ fontSize: 12, color: "#64748b" }}>
@@ -808,7 +808,7 @@
                             borderRadius: 4,
                             padding: 12,
                             fontSize: 13,
-                            color: "#e2e8f0",
+                            color: "#E0DDD8",
                             lineHeight: 1.5,
                           }}
                         >
@@ -954,7 +954,7 @@
                                 borderRadius: 4,
                                 padding: 12,
                                 fontSize: 13,
-                                color: "#e2e8f0",
+                                color: "#E0DDD8",
                                 lineHeight: 1.5,
                               }}
                             >
@@ -1205,7 +1205,7 @@
                     style={{
                       background: playSpeed === sp ? "#1e293b" : "transparent",
                       border: playSpeed === sp ? "1px solid #334155" : "1px solid transparent",
-                      color: playSpeed === sp ? "#e2e8f0" : "#64748b",
+                      color: playSpeed === sp ? "#E0DDD8" : "#64748b",
                       cursor: "pointer",
                       fontSize: 11,
                       padding: "3px 8px",

--- a/scripts/eval_0a.py
+++ b/scripts/eval_0a.py
@@ -163,7 +163,7 @@ You handle schema synthesis — new aides, new sections, restructuring. Emit in 
 - Text entities: write content directly in props. Max ~100 words.
 - Only generate structure the user mentioned or clearly implied. Don't over-scaffold.
 - First creation: include 3-5 starter items in checklists.
-- Default style: {"t":"style.set","p":{"primary_color":"#2d3748","font_family":"Inter","density":"comfortable"}}
+- Default style: {"t":"style.set","p":{"primary_color":"#2D2D2A","font_family":"Inter","density":"comfortable"}}
 
 Queries — always escalate:
 {"t":"escalate","tier":"L4","reason":"query","extract":"the question"}


### PR DESCRIPTION
Closes #46

## Changes
- Update wordmark from "AIde" to "aide" in user-facing contexts (README, email template, flight-recorder)
- Update tagline from "For what you're running." to "For what you're living." across docs
- Update colors: `#2d3748` → `#2D2D2A`, `#e2e8f0` → `#E0DDD8`, `#fafaf9` → `#F7F5F2`
- Update fonts: IBM Plex Sans → DM Sans in test data
- Rewrite `aide_ui_design_system_spec.md` with new brand (Playfair Display, DM Sans, Instrument Sans, sage palette, dark mode, new radius values)
- Update engine test fixtures with new colors

## Files Changed
- `backend/services/email.py` — "AIde" → "aide" in 6 places
- `README.md` — wordmark + tagline
- `CLAUDE.md` — add tagline
- `docs/eng_design/00_overview.md` — tagline fix
- `docs/program_management/aide_launch_plan.md` — tagline fix
- `docs/strategy/aide_engine_distribution.md` — tagline fix
- `frontend/flight-recorder.html` — colors + title
- `scripts/eval_0a.py` — default color
- `engine/kernel/tests/**` — test data colors/fonts
- `docs/eng_design/specs/aide_ui_design_system_spec.md` — full rewrite

## Status
Ready for manual testing. Run `/ship-it <PR_NUM>` when satisfied.

Spec: docs/refactors/aide_brand_update_plan.md