### PR TITLE
refactor: remove workspace R2 uploads, keep only publish

### DIFF
--- a/backend/routes/aides.py
+++ b/backend/routes/aides.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from fastapi.responses import HTMLResponse
 
 from backend.auth import get_current_user
 from backend.models.aide import (
@@ -21,7 +20,6 @@ from backend.models.conversation import ConversationHistoryResponse, MessageResp
 from backend.models.user import User
 from backend.repos.aide_repo import AideRepo
 from backend.repos.conversation_repo import ConversationRepo
-from backend.services.r2 import r2_service
 from backend.utils.snapshot_hash import hash_snapshot
 
 router = APIRouter(prefix="/api/aides", tags=["aides"])
@@ -166,35 +164,6 @@ async def delete_aide(
     return {"message": "Aide deleted."}
 
 
-@router.get("/{aide_id}/preview", status_code=200)
-async def get_aide_preview(
-    aide_id: UUID,
-    user: User = Depends(get_current_user),
-) -> HTMLResponse:
-    """Get rendered HTML preview for an aide (proxied from R2)."""
-    # Verify user owns this aide
-    aide = await aide_repo.get(user.id, aide_id)
-    if not aide:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Aide not found.")
-
-    # Fetch HTML from R2
-    # TODO: Race condition - if user refreshes before R2 upload completes,
-    # R2 returns nothing but aide.state has content. Should fall back to
-    # rendering from aide.state using render_react_preview() instead of
-    # showing "Send a message" placeholder.
-    html_content = await r2_service.get_html(str(aide_id))
-    if not html_content:
-        # Return placeholder if no HTML yet
-        html_content = (
-            '<!DOCTYPE html><html><body style="background:#f9f9f9;'
-            "display:flex;align-items:center;justify-content:center;"
-            'height:100vh;font-family:sans-serif;color:#aaa;font-size:14px;">'
-            "Send a message to get started.</body></html>"
-        )
-
-    return HTMLResponse(content=html_content)
-
-
 @router.get("/{aide_id}/state", status_code=200)
 async def get_aide_state(
     aide_id: UUID,
@@ -245,13 +214,11 @@ async def save_aide_state(
     user: User = Depends(get_current_user),
 ) -> SaveStateResponse:
     """
-    Save streamed state to database and R2.
+    Save streamed state to database.
 
     This endpoint persists the state that was streamed via WebSocket.
     No LLM call - just saves what the frontend already has.
     """
-    from backend.services.renderer import render_html
-
     # Verify user owns this aide
     aide = await aide_repo.get(user.id, aide_id)
     if not aide:
@@ -269,10 +236,6 @@ async def save_aide_state(
     # Update aide state in database
     title = req.meta.get("title") or aide.title
     await aide_repo.update_state(user.id, aide_id, snapshot, event_log=[], title=title)
-
-    # Render HTML and upload to R2
-    html_content = render_html(snapshot, title=title)
-    await r2_service.upload_html(str(aide_id), html_content)
 
     # Save conversation history if provided
     if req.message or req.response:

--- a/backend/routes/ws.py
+++ b/backend/routes/ws.py
@@ -22,7 +22,6 @@ from backend.config import settings
 from backend.models.telemetry import TelemetryEvent
 from backend.repos import telemetry_repo
 from backend.repos.aide_repo import AideRepo
-from backend.services.renderer import render_html
 from backend.services.streaming_orchestrator import StreamingOrchestrator
 from engine.kernel.mock_llm import MockLLM
 from engine.kernel.reducer_v2 import empty_snapshot, reduce
@@ -81,7 +80,7 @@ async def _load_snapshot(user_id: UUID | None, aide_id: str) -> dict[str, Any]:
 
 async def _save_snapshot(user_id: UUID | None, aide_id: str, snapshot: dict[str, Any]) -> None:
     """
-    Save snapshot to database and R2 for the given aide.
+    Save snapshot to database for the given aide.
     """
     if not user_id or not _UUID_RE.match(aide_id):
         return
@@ -90,13 +89,6 @@ async def _save_snapshot(user_id: UUID | None, aide_id: str, snapshot: dict[str,
         aide_uuid = UUID(aide_id)
         title = snapshot.get("meta", {}).get("title")
         await aide_repo.update_state(user_id, aide_uuid, snapshot, event_log=[], title=title)
-
-        # Also render and upload to R2
-        from backend.services.r2 import r2_service
-
-        html_content = render_html(snapshot, title=title)
-        await r2_service.upload_html(aide_id, html_content)
-
         logger.info("ws: saved %d entities for aide_id=%s", len(snapshot.get("entities", {})), aide_id)
     except Exception as e:
         logger.warning("ws: failed to save snapshot for aide_id=%s: %s", aide_id, e)

--- a/backend/services/orchestrator.py
+++ b/backend/services/orchestrator.py
@@ -17,8 +17,6 @@ from backend.services.flight_recorder_uploader import flight_recorder_uploader
 from backend.services.grid_resolver import resolve_primitives
 from backend.services.l2_compiler import l2_compiler
 from backend.services.l3_synthesizer import l3_synthesizer
-from backend.services.r2 import r2_service
-from backend.services.renderer import render_html
 from engine.kernel.reducer_v2 import empty_snapshot as empty_v2_snapshot
 from engine.kernel.reducer_v2 import reduce
 from engine.kernel.types import Event, ReduceResult
@@ -259,11 +257,7 @@ class Orchestrator:
 
         print(f"Orchestrator: {applied_count}/{len(v2_events)} events applied successfully")
 
-        # 5. Render HTML
-        title = new_snapshot.get("meta", {}).get("title") or (aide.title if hasattr(aide, "title") else "AIde")
-        html_content = render_html(new_snapshot, title=title)
-
-        # 6. Save state to DB
+        # 5. Save state to DB
         serialized_events = [
             {
                 "id": e.id,
@@ -282,14 +276,7 @@ class Orchestrator:
         new_title = new_snapshot.get("meta", {}).get("title")
         await self.aide_repo.update_state(user_id, aide_id, new_snapshot, updated_event_log, title=new_title)
 
-        # 7. Upload HTML to R2 (non-blocking — DB is source of truth)
-        try:
-            await r2_service.upload_html(str(aide_id), html_content)
-        except Exception as e:
-            # Log but don't fail — state is saved in DB, R2 is just a cache
-            print(f"R2 upload failed (will retry on next message): {e}")
-
-        # 8. Save messages to conversation
+        # 6. Save messages to conversation
         user_message = Message(
             role="user",
             content=message,

--- a/backend/tests/test_flight_recorder.py
+++ b/backend/tests/test_flight_recorder.py
@@ -389,7 +389,6 @@ class TestOrchestratorFlightRecorderIntegration:
 
         with (
             patch("backend.services.orchestrator.l3_synthesizer") as mock_l3,
-            patch("backend.services.orchestrator.r2_service") as mock_r2,
             patch("backend.services.orchestrator.flight_recorder_uploader") as mock_uploader,
         ):
             orch = Orchestrator()
@@ -411,7 +410,6 @@ class TestOrchestratorFlightRecorderIntegration:
             orch.conv_repo.get_for_aide = AsyncMock(return_value=mock_conv_obj)
             orch.conv_repo.append_message = AsyncMock()
 
-            mock_r2.upload_html = AsyncMock()
 
             mock_l3.synthesize = AsyncMock(return_value={"primitives": [], "response": "Noted."})
 
@@ -447,7 +445,6 @@ class TestOrchestratorFlightRecorderIntegration:
 
         with (
             patch("backend.services.orchestrator.l3_synthesizer") as mock_l3,
-            patch("backend.services.orchestrator.r2_service") as mock_r2,
             patch("backend.services.orchestrator.flight_recorder_uploader"),
         ):
             orch = Orchestrator()
@@ -469,7 +466,6 @@ class TestOrchestratorFlightRecorderIntegration:
             orch.conv_repo.get_for_aide = AsyncMock(return_value=mock_conv_obj)
             orch.conv_repo.append_message = AsyncMock()
 
-            mock_r2.upload_html = AsyncMock()
 
             mock_l3.synthesize = AsyncMock(return_value={"primitives": [], "response": "Done."})
             mock_l3.system_prompt = "system"

--- a/backend/tests/test_orchestrator.py
+++ b/backend/tests/test_orchestrator.py
@@ -91,7 +91,6 @@ class TestL3Synthesis:
         """L3 creates schema from first message."""
         with (
             patch("backend.services.orchestrator.l3_synthesizer") as mock_l3,
-            patch("backend.services.orchestrator.r2_service") as mock_r2,
         ):
             # Create orchestrator with mocked repos
             orchestrator = Orchestrator()
@@ -116,7 +115,6 @@ class TestL3Synthesis:
             orchestrator.conv_repo.create = AsyncMock(return_value=mock_conv_obj)
             orchestrator.conv_repo.append_message = AsyncMock()
 
-            mock_r2.upload_html = AsyncMock(return_value="aide_123/index.html")
 
             # L3 returns primitives to create grocery list
             mock_l3.synthesize = AsyncMock(
@@ -172,7 +170,6 @@ class TestL3Synthesis:
         """Image input routes to L3 (vision-capable model)."""
         with (
             patch("backend.services.orchestrator.l3_synthesizer") as mock_l3,
-            patch("backend.services.orchestrator.r2_service") as mock_r2,
         ):
             orchestrator = Orchestrator()
             orchestrator.aide_repo = MagicMock()
@@ -193,7 +190,6 @@ class TestL3Synthesis:
             orchestrator.conv_repo.get_for_aide = AsyncMock(return_value=mock_conv_obj)
             orchestrator.conv_repo.append_message = AsyncMock()
 
-            mock_r2.upload_html = AsyncMock(return_value="aide_123/index.html")
 
             mock_l3.synthesize = AsyncMock(return_value={"primitives": [], "response": "Receipt processed."})
 
@@ -221,7 +217,6 @@ class TestL2Compilation:
         """Routine update uses L2 (Haiku)."""
         with (
             patch("backend.services.orchestrator.l2_compiler") as mock_l2,
-            patch("backend.services.orchestrator.r2_service") as mock_r2,
         ):
             orchestrator = Orchestrator()
             orchestrator.aide_repo = MagicMock()
@@ -242,7 +237,6 @@ class TestL2Compilation:
             orchestrator.conv_repo.get_for_aide = AsyncMock(return_value=mock_conv_obj)
             orchestrator.conv_repo.append_message = AsyncMock()
 
-            mock_r2.upload_html = AsyncMock(return_value="aide_456/index.html")
 
             # L2 returns primitive to check off milk
             mock_l2.compile = AsyncMock(
@@ -284,7 +278,6 @@ class TestL2Compilation:
         with (
             patch("backend.services.orchestrator.l2_compiler") as mock_l2,
             patch("backend.services.orchestrator.l3_synthesizer") as mock_l3,
-            patch("backend.services.orchestrator.r2_service") as mock_r2,
         ):
             orchestrator = Orchestrator()
             orchestrator.aide_repo = MagicMock()
@@ -305,7 +298,6 @@ class TestL2Compilation:
             orchestrator.conv_repo.get_for_aide = AsyncMock(return_value=mock_conv_obj)
             orchestrator.conv_repo.append_message = AsyncMock()
 
-            mock_r2.upload_html = AsyncMock(return_value="aide_456/index.html")
 
             # L2 signals escalation
             mock_l2.compile = AsyncMock(
@@ -354,7 +346,6 @@ class TestL2Compilation:
         """L2 handles multi-entity updates."""
         with (
             patch("backend.services.orchestrator.l2_compiler") as mock_l2,
-            patch("backend.services.orchestrator.r2_service") as mock_r2,
         ):
             orchestrator = Orchestrator()
             orchestrator.aide_repo = MagicMock()
@@ -375,7 +366,6 @@ class TestL2Compilation:
             orchestrator.conv_repo.get_for_aide = AsyncMock(return_value=mock_conv_obj)
             orchestrator.conv_repo.append_message = AsyncMock()
 
-            mock_r2.upload_html = AsyncMock(return_value="aide_456/index.html")
 
             # L2 returns multiple primitives
             mock_l2.compile = AsyncMock(
@@ -421,7 +411,6 @@ class TestOrchestrationFlow:
         """Full flow: message → primitives → state → render → R2."""
         with (
             patch("backend.services.orchestrator.l2_compiler") as mock_l2,
-            patch("backend.services.orchestrator.r2_service") as mock_r2,
         ):
             orchestrator = Orchestrator()
             orchestrator.aide_repo = MagicMock()
@@ -442,7 +431,6 @@ class TestOrchestrationFlow:
             orchestrator.conv_repo.get_for_aide = AsyncMock(return_value=mock_conv_obj)
             orchestrator.conv_repo.append_message = AsyncMock()
 
-            mock_r2.upload_html = AsyncMock(return_value="aide_456/index.html")
 
             mock_l2.compile = AsyncMock(
                 return_value={
@@ -471,11 +459,6 @@ class TestOrchestrationFlow:
             # Verify state was saved
             orchestrator.aide_repo.update_state.assert_called_once()
 
-            # Verify HTML was uploaded to R2
-            mock_r2.upload_html.assert_called_once()
-            uploaded_html = mock_r2.upload_html.call_args[0][1]
-            assert "<!DOCTYPE html>" in uploaded_html
-
             # Verify conversation messages were saved
             assert orchestrator.conv_repo.append_message.call_count == 2  # user + assistant
 
@@ -489,7 +472,6 @@ class TestOrchestrationFlow:
         """Questions don't mutate state."""
         with (
             patch("backend.services.orchestrator.l2_compiler") as mock_l2,
-            patch("backend.services.orchestrator.r2_service") as mock_r2,
         ):
             orchestrator = Orchestrator()
             orchestrator.aide_repo = MagicMock()
@@ -510,7 +492,6 @@ class TestOrchestrationFlow:
             orchestrator.conv_repo.get_for_aide = AsyncMock(return_value=mock_conv_obj)
             orchestrator.conv_repo.append_message = AsyncMock()
 
-            mock_r2.upload_html = AsyncMock(return_value="aide_456/index.html")
 
             # L2 returns no primitives for question
             mock_l2.compile = AsyncMock(


### PR DESCRIPTION
## Summary
Remove redundant R2 uploads on every state change. R2 HTML upload now only happens on explicit publish.

## Changes
- Removed `upload_html` from `ws.py` (was uploading on every save)
- Removed `upload_html` from `aides.py` state endpoint
- Removed `upload_html` from `orchestrator.py`
- Removed `/api/aides/{id}/preview` endpoint (was reading from workspace bucket)
- Updated tests to remove related mocks

**Architecture clarification:** Editor uses client-side React rendering. R2 HTML upload only happens on explicit publish for static hosted pages.

## Test plan
- [ ] Verify editor still works without R2 workspace uploads
- [ ] Verify publish flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)