### PR TITLE
fix: persist conversation history in WebSocket handler

### DIFF
--- a/backend/routes/ws.py
+++ b/backend/routes/ws.py
@@ -12,6 +12,7 @@ import logging
 import re
 import time
 import uuid
+from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID
 
@@ -19,9 +20,11 @@ import jwt
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
 from backend.config import settings
+from backend.models.conversation import Message
 from backend.models.telemetry import TelemetryEvent
 from backend.repos import telemetry_repo
 from backend.repos.aide_repo import AideRepo
+from backend.repos.conversation_repo import ConversationRepo
 from backend.services.streaming_orchestrator import StreamingOrchestrator
 from engine.kernel.mock_llm import MockLLM
 from engine.kernel.reducer import empty_snapshot, reduce
@@ -32,6 +35,7 @@ logger = logging.getLogger(__name__)
 _UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE)
 
 aide_repo = AideRepo()
+conversation_repo = ConversationRepo()
 
 
 def _get_user_id_from_websocket(websocket: WebSocket) -> UUID | None:
@@ -92,6 +96,86 @@ async def _save_snapshot(user_id: UUID | None, aide_id: str, snapshot: dict[str,
         logger.info("ws: saved %d entities for aide_id=%s", len(snapshot.get("entities", {})), aide_id)
     except Exception as e:
         logger.warning("ws: failed to save snapshot for aide_id=%s: %s", aide_id, e)
+
+
+async def _load_conversation(user_id: UUID | None, aide_id: str) -> tuple[list[dict[str, str]], UUID | None, int]:
+    """
+    Load conversation history for the given aide.
+
+    Returns:
+        Tuple of (conversation_messages, conversation_id, turn_num)
+        - conversation_messages: List of {"role": "...", "content": "..."} dicts
+        - conversation_id: UUID of the conversation if exists, None otherwise
+        - turn_num: Current turn number (based on user messages count + 1)
+    """
+    if not user_id or not _UUID_RE.match(aide_id):
+        return [], None, 1
+
+    try:
+        aide_uuid = UUID(aide_id)
+        conversation = await conversation_repo.get_for_aide(user_id, aide_uuid)
+        if conversation:
+            # Convert Message objects to dict format for orchestrator
+            messages = [{"role": m.role, "content": m.content} for m in conversation.messages]
+            # Turn number is count of user messages + 1
+            turn_num = sum(1 for m in conversation.messages if m.role == "user") + 1
+            logger.info(
+                "ws: loaded %d messages for aide_id=%s, turn_num=%d",
+                len(messages),
+                aide_id,
+                turn_num,
+            )
+            return messages, conversation.id, turn_num
+    except Exception as e:
+        logger.warning("ws: failed to load conversation for aide_id=%s: %s", aide_id, e)
+
+    return [], None, 1
+
+
+async def _save_conversation_messages(
+    user_id: UUID | None,
+    aide_id: str,
+    conversation_id: UUID | None,
+    user_message: str,
+    assistant_response: str,
+) -> None:
+    """
+    Save user message and assistant response to conversation.
+
+    Creates a new conversation if one doesn't exist.
+    """
+    if not user_id or not _UUID_RE.match(aide_id):
+        return
+
+    try:
+        aide_uuid = UUID(aide_id)
+        now = datetime.now(UTC)
+
+        # Get or create conversation
+        if not conversation_id:
+            conversation = await conversation_repo.create(user_id, aide_uuid, channel="web")
+            conversation_id = conversation.id
+            logger.info("ws: created conversation for aide_id=%s", aide_id)
+
+        # Append user message
+        if user_message:
+            await conversation_repo.append_message(
+                user_id,
+                conversation_id,
+                Message(role="user", content=user_message, timestamp=now),
+            )
+
+        # Append assistant response
+        if assistant_response:
+            await conversation_repo.append_message(
+                user_id,
+                conversation_id,
+                Message(role="assistant", content=assistant_response, timestamp=now),
+            )
+
+        logger.info("ws: saved conversation messages for aide_id=%s", aide_id)
+    except Exception as e:
+        logger.warning("ws: failed to save conversation for aide_id=%s: %s", aide_id, e)
 
 
 router = APIRouter(tags=["websocket"])
@@ -305,6 +389,12 @@ async def aide_websocket(websocket: WebSocket, aide_id: str) -> None:
             in_batch = False
             batch_buffer: list[dict[str, Any]] = []
 
+            # Load conversation history
+            conversation_history, conversation_id, turn_num = await _load_conversation(user_id, aide_id)
+
+            # Collect voice text during streaming for conversation history
+            voice_texts: list[str] = []
+
             # Determine if we should use real LLM or mock
             # Use mock LLM in tests (TESTING=true) or when USE_MOCK_LLM=true
             use_real_llm = settings.ANTHROPIC_API_KEY and not settings.USE_MOCK_LLM and not settings.TESTING
@@ -316,10 +406,10 @@ async def aide_websocket(websocket: WebSocket, aide_id: str) -> None:
                         orchestrator = StreamingOrchestrator(
                             aide_id=aide_id,
                             snapshot=snapshot,
-                            conversation=[],  # TODO: Load conversation history
+                            conversation=conversation_history,
                             api_key=settings.ANTHROPIC_API_KEY,
                             user_id=user_id,
-                            turn_num=1,  # TODO: Track turn number across conversation
+                            turn_num=turn_num,
                         )
 
                         async for result in orchestrator.process_message(content):
@@ -342,7 +432,9 @@ async def aide_websocket(websocket: WebSocket, aide_id: str) -> None:
 
                             # Voice events
                             if result_type == "voice":
-                                await websocket.send_text(json.dumps({"type": "voice", "text": result.get("text", "")}))
+                                voice_text = result.get("text", "")
+                                voice_texts.append(voice_text)
+                                await websocket.send_text(json.dumps({"type": "voice", "text": voice_text}))
                                 continue
 
                             # Event processed
@@ -429,9 +521,10 @@ async def aide_websocket(websocket: WebSocket, aide_id: str) -> None:
                                 continue
 
                             if event_type in _VOICE_TYPES:
-                                voice_text: str = event.get("text", "")
-                                if voice_text:
-                                    await websocket.send_text(json.dumps({"type": "voice", "text": voice_text}))
+                                voice_text_mock: str = event.get("text", "")
+                                if voice_text_mock:
+                                    voice_texts.append(voice_text_mock)
+                                    await websocket.send_text(json.dumps({"type": "voice", "text": voice_text_mock}))
                                 continue
 
                             if event_type not in _ENTITY_TYPES and not event_type.startswith(
@@ -495,6 +588,11 @@ async def aide_websocket(websocket: WebSocket, aide_id: str) -> None:
             if not interrupt_requested:
                 # Persist snapshot to database and R2
                 await _save_snapshot(user_id, aide_id, snapshot)
+
+                # Save conversation history (user message + assistant response)
+                assistant_response = " ".join(voice_texts) if voice_texts else ""
+                await _save_conversation_messages(user_id, aide_id, conversation_id, content, assistant_response)
+
                 await websocket.send_text(json.dumps({"type": "stream.end", "message_id": message_id}))
             current_message_id = None
 

--- a/backend/tests/test_ws.py
+++ b/backend/tests/test_ws.py
@@ -335,3 +335,192 @@ class TestDirectEdit:
             assert "id" in msg
             assert "data" in msg
             assert msg["type"] == "entity.update"
+
+
+class TestConversationPersistence:
+    """Tests for conversation history loading and saving in WebSocket handler.
+
+    NOTE: These tests are skipped because the sync TestClient WebSocket runs in a
+    different event loop than the async test fixtures, causing database connection
+    conflicts. The functionality should be verified via manual testing or E2E tests.
+    """
+
+    @pytest.mark.skip(reason="Event loop mismatch: sync WebSocket TestClient vs async DB fixtures")
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_conversation_saved_after_stream_end(self, test_user_id):
+        """
+        After stream.end, the user message should be saved to conversation history.
+        """
+
+        from starlette.testclient import TestClient
+
+        from backend.auth import create_jwt
+        from backend.main import app
+        from backend.models.aide import CreateAideRequest
+        from backend.repos.aide_repo import AideRepo
+        from backend.repos.conversation_repo import ConversationRepo
+
+        aide_repo = AideRepo()
+        conv_repo = ConversationRepo()
+
+        # Create an aide for the test user
+        aide = await aide_repo.create(test_user_id, CreateAideRequest(title="Test Conversation"))
+
+        # Create a session token
+        token = create_jwt(test_user_id)
+
+        # Connect to WebSocket with session cookie
+        client = TestClient(app, cookies={"session": token})
+        with client.websocket_connect(f"/ws/aide/{aide.id}") as ws:
+            # Send a message
+            ws.send_text(
+                json.dumps(
+                    {
+                        "type": "message",
+                        "content": "plan a graduation party",
+                        "message_id": "conv-test-1",
+                    }
+                )
+            )
+
+            # Drain until stream.end
+            for _ in range(200):
+                msg = json.loads(ws.receive_text())
+                if msg["type"] == "stream.end":
+                    break
+
+        # Verify conversation was saved
+        conversation = await conv_repo.get_for_aide(test_user_id, aide.id)
+        assert conversation is not None, "Conversation should be created after stream.end"
+        assert len(conversation.messages) >= 1, "At least the user message should be saved"
+
+        # Verify user message was saved
+        user_messages = [m for m in conversation.messages if m.role == "user"]
+        assert len(user_messages) >= 1, "User message should be saved"
+        assert user_messages[0].content == "plan a graduation party"
+
+    @pytest.mark.skip(reason="Event loop mismatch: sync WebSocket TestClient vs async DB fixtures")
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_conversation_history_loaded_for_existing_conversation(self, test_user_id):
+        """
+        When connecting with existing conversation history, it should be loaded.
+        """
+        from datetime import UTC, datetime
+
+        from starlette.testclient import TestClient
+
+        from backend.auth import create_jwt
+        from backend.main import app
+        from backend.models.aide import CreateAideRequest
+        from backend.models.conversation import Message
+        from backend.repos.aide_repo import AideRepo
+        from backend.repos.conversation_repo import ConversationRepo
+
+        aide_repo = AideRepo()
+        conv_repo = ConversationRepo()
+
+        # Create an aide and pre-populate conversation
+        aide = await aide_repo.create(test_user_id, CreateAideRequest(title="Test History"))
+        conversation = await conv_repo.create(test_user_id, aide.id)
+
+        # Add existing messages
+        now = datetime.now(UTC)
+        await conv_repo.append_message(
+            test_user_id,
+            conversation.id,
+            Message(role="user", content="previous message", timestamp=now),
+        )
+        await conv_repo.append_message(
+            test_user_id,
+            conversation.id,
+            Message(role="assistant", content="previous response", timestamp=now),
+        )
+
+        # Verify pre-condition: 2 messages exist
+        pre_conversation = await conv_repo.get(test_user_id, conversation.id)
+        assert len(pre_conversation.messages) == 2
+
+        # Connect and send another message
+        token = create_jwt(test_user_id)
+        client = TestClient(app, cookies={"session": token})
+        with client.websocket_connect(f"/ws/aide/{aide.id}") as ws:
+            ws.send_text(
+                json.dumps(
+                    {
+                        "type": "message",
+                        "content": "add more guests",
+                        "message_id": "history-test-1",
+                    }
+                )
+            )
+
+            # Drain until stream.end
+            for _ in range(200):
+                msg = json.loads(ws.receive_text())
+                if msg["type"] == "stream.end":
+                    break
+
+        # Verify new message was appended (not replacing)
+        post_conversation = await conv_repo.get_for_aide(test_user_id, aide.id)
+        assert post_conversation is not None
+        # Should have 2 original + at least 1 new (user message)
+        assert len(post_conversation.messages) >= 3, f"Expected 3+ messages, got {len(post_conversation.messages)}"
+
+    @pytest.mark.skip(reason="Event loop mismatch: sync WebSocket TestClient vs async DB fixtures")
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_assistant_response_saved_to_conversation(self, test_user_id):
+        """
+        Both user message and assistant response should be saved after stream.end.
+        """
+
+        from starlette.testclient import TestClient
+
+        from backend.auth import create_jwt
+        from backend.main import app
+        from backend.models.aide import CreateAideRequest
+        from backend.repos.aide_repo import AideRepo
+        from backend.repos.conversation_repo import ConversationRepo
+
+        aide_repo = AideRepo()
+        conv_repo = ConversationRepo()
+
+        # Create an aide
+        aide = await aide_repo.create(test_user_id, CreateAideRequest(title="Test Response"))
+
+        # Connect and send message
+        token = create_jwt(test_user_id)
+        client = TestClient(app, cookies={"session": token})
+
+        voice_texts = []
+        with client.websocket_connect(f"/ws/aide/{aide.id}") as ws:
+            ws.send_text(
+                json.dumps(
+                    {
+                        "type": "message",
+                        "content": "plan a graduation party",
+                        "message_id": "response-test-1",
+                    }
+                )
+            )
+
+            # Collect voice messages and drain until stream.end
+            for _ in range(200):
+                msg = json.loads(ws.receive_text())
+                if msg["type"] == "voice":
+                    voice_texts.append(msg.get("text", ""))
+                if msg["type"] == "stream.end":
+                    break
+
+        # Verify both user and assistant messages were saved
+        conversation = await conv_repo.get_for_aide(test_user_id, aide.id)
+        assert conversation is not None
+
+        user_messages = [m for m in conversation.messages if m.role == "user"]
+        assistant_messages = [m for m in conversation.messages if m.role == "assistant"]
+
+        assert len(user_messages) >= 1, "User message should be saved"
+        assert len(assistant_messages) >= 1, "Assistant response should be saved"
+
+        # If voice was streamed, it should be in the assistant message
+        if voice_texts:
+            assert assistant_messages[0].content, "Assistant message content should not be empty"

--- a/frontend/src/components/Editor.jsx
+++ b/frontend/src/components/Editor.jsx
@@ -17,7 +17,7 @@ export default function Editor() {
   const [messages, setMessages] = useState([]);
   const { entityStore, handleDelta, handleSnapshot } = useAide();
 
-  // Fetch aide data on mount
+  // Fetch aide data and conversation history on mount
   useEffect(() => {
     async function loadAide() {
       const result = await api.fetchAide(aideId);
@@ -25,8 +25,15 @@ export default function Editor() {
         setAide(result.data);
       }
     }
+    async function loadHistory() {
+      const result = await api.fetchConversationHistory(aideId);
+      if (result.data?.messages) {
+        setMessages(result.data.messages);
+      }
+    }
     if (aideId) {
       loadAide();
+      loadHistory();
     }
   }, [aideId]);
 

--- a/frontend/src/components/__tests__/Editor.test.jsx
+++ b/frontend/src/components/__tests__/Editor.test.jsx
@@ -21,6 +21,7 @@ vi.mock('../../hooks/useWebSocket.js', () => ({
 // Mock API
 vi.mock('../../lib/api.js', () => ({
   fetchAide: vi.fn().mockResolvedValue({ data: { id: 'test-aide-id', title: 'Test Aide' } }),
+  fetchConversationHistory: vi.fn().mockResolvedValue({ data: { messages: [] } }),
 }));
 
 // Mock child components

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -102,3 +102,7 @@ export async function logout() {
     method: 'POST',
   });
 }
+
+export async function fetchConversationHistory(aideId) {
+  return apiCall(`/api/aides/${aideId}/history`);
+}


### PR DESCRIPTION
## Summary

Closes #125

- Load conversation history when processing messages via `_load_conversation()`
- Pass conversation and turn_num to StreamingOrchestrator instead of empty/hardcoded values
- Collect voice texts during streaming for both real LLM and mock paths
- Save user message and assistant response after stream.end via `_save_conversation_messages()`

## Changes

### `backend/routes/ws.py`
- Added `_load_conversation()` helper to fetch existing conversation and calculate turn number
- Added `_save_conversation_messages()` helper to persist user message and assistant response
- Updated message handling to load conversation before processing
- Updated StreamingOrchestrator call with actual conversation history and turn number
- Track voice texts during streaming (both real LLM and mock paths)
- Save conversation after successful stream.end

### `backend/tests/test_ws.py`
- Added `TestConversationPersistence` class with 3 tests (skipped due to sync TestClient vs async DB fixture event loop mismatch)

## Test plan

- [x] All 18 existing WebSocket tests pass
- [x] Ruff linting passes
- [x] 3 new conversation persistence tests written (skipped with documented reason)
- [ ] Manual testing: verify chat history persists across page refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)