### PR TITLE
refactor: rename reducer to kernel, reduce() to apply()

### DIFF
--- a/backend/routes/conversations.py
+++ b/backend/routes/conversations.py
@@ -12,7 +12,7 @@ from backend.models.aide import CreateAideRequest, SendMessageRequest, SendMessa
 from backend.models.user import User
 from backend.repos.aide_repo import AideRepo
 from backend.services.streaming_orchestrator import StreamingOrchestrator
-from engine.kernel.reducer import empty_snapshot
+from engine.kernel import empty_snapshot
 
 router = APIRouter(prefix="/api", tags=["conversations"])
 aide_repo = AideRepo()

--- a/backend/routes/ws.py
+++ b/backend/routes/ws.py
@@ -2,7 +2,7 @@
 WebSocket endpoint for real-time aide interaction.
 
 Accepts connections at /ws/aide/{aide_id}, streams deltas back to the client
-as the LLM processes tool calls through the reducer.
+as the LLM processes tool calls through the kernel.
 """
 
 from __future__ import annotations
@@ -26,7 +26,7 @@ from backend.repos import telemetry_repo
 from backend.repos.aide_repo import AideRepo
 from backend.repos.conversation_repo import ConversationRepo
 from backend.services.streaming_orchestrator import StreamingOrchestrator
-from engine.kernel.reducer import empty_snapshot, reduce
+from engine.kernel import apply, empty_snapshot
 
 logger = logging.getLogger(__name__)
 
@@ -240,11 +240,11 @@ async def _handle_direct_edit(
     # Build entity.update event (v2 format: short keys; uses "ref" not "id")
     event: dict[str, Any] = {"t": "entity.update", "ref": entity_id, "p": {field: value}}
 
-    result = reduce(snapshot, event)
+    result = apply(snapshot, event)
 
     if not result.accepted:
         logger.warning(
-            "ws: direct_edit reducer rejected: entity=%s field=%s reason=%s",
+            "ws: direct_edit kernel rejected: entity=%s field=%s reason=%s",
             entity_id,
             field,
             result.reason,

--- a/backend/services/streaming_orchestrator.py
+++ b/backend/services/streaming_orchestrator.py
@@ -22,7 +22,7 @@ from backend.services.escalation import needs_escalation
 from backend.services.prompt_builder import build_messages, build_system_blocks
 from backend.services.telemetry import TurnRecorder
 from backend.services.tool_defs import TOOLS
-from engine.kernel.reducer import reduce
+from engine.kernel import apply
 
 logger = logging.getLogger(__name__)
 
@@ -233,8 +233,8 @@ class StreamingOrchestrator:
                     text_blocks.append({"text": event.get("text", "")})
                     continue
 
-                # Apply event to working snapshot through reducer
-                result = reduce(working_snapshot, event)
+                # Apply event to working snapshot through kernel
+                result = apply(working_snapshot, event)
 
                 if result.accepted:
                     working_snapshot = result.snapshot

--- a/backend/tests/test_orchestrator_telemetry.py
+++ b/backend/tests/test_orchestrator_telemetry.py
@@ -10,7 +10,7 @@ from backend.models.aide import CreateAideRequest
 from backend.repos import telemetry_repo
 from backend.repos.aide_repo import AideRepo
 from backend.services.streaming_orchestrator import StreamingOrchestrator
-from engine.kernel.reducer import empty_snapshot
+from engine.kernel import empty_snapshot
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 

--- a/engine/kernel/__init__.py
+++ b/engine/kernel/__init__.py
@@ -1,12 +1,15 @@
 """
-AIde Kernel — the pure reducer.
+AIde Kernel
 
-reduce(snapshot, event) → ReduceResult (pure, deterministic)
+apply(snapshot, event) → ApplyResult (pure, deterministic)
 """
 
-from engine.kernel.reducer import empty_snapshot, reduce
+from engine.kernel.kernel import apply, apply_all, empty_snapshot, replay, ApplyResult
 
 __all__ = [
+    "apply",
+    "apply_all",
     "empty_snapshot",
-    "reduce",
+    "replay",
+    "ApplyResult",
 ]

--- a/engine/kernel/kernel.py
+++ b/engine/kernel/kernel.py
@@ -1,17 +1,15 @@
 """
-AIde Kernel — v2 Reducer
+AIde Kernel
 
-Pure function: (snapshot, event) → ReduceResult
+Pure function: apply(snapshot, event) → ApplyResult
 
-The v2 reducer handles the simplified JSONL event format used by the AI compiler.
+The kernel handles entity mutations via tool call events.
 Events use short-hand keys: t (type), p (props), ref, id, parent, display.
 
-This is a rewrite of the v1 reducer with a flat entity hierarchy:
-- No collections — entities are stored flat with parent references
+Flat entity hierarchy:
+- Entities are stored flat with parent references
 - "root" is the implicit top-level parent
 - entity.create with parent=None or parent="root" creates top-level entities
-
-Reference: docs/program_management/PHASE_0B_REDUCER.md
 """
 
 from __future__ import annotations
@@ -71,11 +69,11 @@ def empty_snapshot() -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
-# ReduceResult
+# ApplyResult
 # ---------------------------------------------------------------------------
 
 
-class ReduceResult:
+class ApplyResult:
     """
     Result of applying one v2 event to a snapshot.
     Never throws — always returns one of these.
@@ -97,8 +95,8 @@ class ReduceResult:
 
     def __repr__(self) -> str:  # pragma: no cover
         if self.accepted:
-            return "ReduceResult(accepted=True)"
-        return f"ReduceResult(accepted=False, reason={self.reason!r})"
+            return "ApplyResult(accepted=True)"
+        return f"ApplyResult(accepted=False, reason={self.reason!r})"
 
 
 # ---------------------------------------------------------------------------
@@ -106,12 +104,12 @@ class ReduceResult:
 # ---------------------------------------------------------------------------
 
 
-def _reject(snap: dict, reason: str) -> ReduceResult:
-    return ReduceResult(snapshot=snap, accepted=False, reason=reason)
+def _reject(snap: dict, reason: str) -> ApplyResult:
+    return ApplyResult(snapshot=snap, accepted=False, reason=reason)
 
 
-def _ok(snap: dict, signal: dict[str, Any] | None = None) -> ReduceResult:
-    return ReduceResult(snapshot=snap, accepted=True, signal=signal)
+def _ok(snap: dict, signal: dict[str, Any] | None = None) -> ApplyResult:
+    return ApplyResult(snapshot=snap, accepted=True, signal=signal)
 
 
 def _inc(snap: dict) -> int:
@@ -162,20 +160,20 @@ def _cascade_remove(snap: dict, entity_id: str, seq: int) -> None:
 # ---------------------------------------------------------------------------
 
 
-def reduce(snapshot: dict[str, Any], event: dict[str, Any]) -> ReduceResult:
+def apply(snapshot: dict[str, Any], event: dict[str, Any]) -> ApplyResult:
     """
-    Apply one v2 event to the current snapshot.
-    Returns ReduceResult with new snapshot + accepted flag.
+    Apply one event to the current snapshot.
+    Returns ApplyResult with new snapshot + accepted flag.
 
     Pure function. Input snapshot is never modified (deep copy on mutation).
     """
     event_type = event.get("t")
     if event_type is None:
-        return ReduceResult(snapshot=snapshot, accepted=False, reason="MISSING_TYPE: event has no 't' field")
+        return ApplyResult(snapshot=snapshot, accepted=False, reason="MISSING_TYPE: event has no 't' field")
 
     handler = _HANDLERS.get(event_type)
     if handler is None:
-        return ReduceResult(
+        return ApplyResult(
             snapshot=snapshot,
             accepted=False,
             reason=f"UNKNOWN_PRIMITIVE: {event_type}",
@@ -185,7 +183,7 @@ def reduce(snapshot: dict[str, Any], event: dict[str, Any]) -> ReduceResult:
     return handler(snap, event)
 
 
-def reduce_all(snapshot: dict[str, Any], events: list[dict[str, Any]]) -> dict[str, Any]:
+def apply_all(snapshot: dict[str, Any], events: list[dict[str, Any]]) -> dict[str, Any]:
     """
     Apply a sequence of events to a snapshot.
     Signals are accepted but don't mutate snapshot.
@@ -193,15 +191,15 @@ def reduce_all(snapshot: dict[str, Any], events: list[dict[str, Any]]) -> dict[s
     Returns the final snapshot.
     """
     for event in events:
-        result = reduce(snapshot, event)
+        result = apply(snapshot, event)
         if result.accepted:
             snapshot = result.snapshot
     return snapshot
 
 
 def replay(events: list[dict[str, Any]]) -> dict[str, Any]:
-    """Rebuild snapshot from scratch by reducing over all events."""
-    return reduce_all(empty_snapshot(), events)
+    """Rebuild snapshot from scratch by applying all events."""
+    return apply_all(empty_snapshot(), events)
 
 
 # ---------------------------------------------------------------------------
@@ -209,7 +207,7 @@ def replay(events: list[dict[str, Any]]) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def _handle_entity_create(snap: dict, event: dict) -> ReduceResult:
+def _handle_entity_create(snap: dict, event: dict) -> ApplyResult:
     entity_id = event.get("id")
     parent = event.get("parent", "root")
     display = event.get("display")
@@ -254,7 +252,7 @@ def _handle_entity_create(snap: dict, event: dict) -> ReduceResult:
     return _ok(snap)
 
 
-def _handle_entity_update(snap: dict, event: dict) -> ReduceResult:
+def _handle_entity_update(snap: dict, event: dict) -> ApplyResult:
     ref = event.get("ref")
     props = event.get("p", {})
 
@@ -272,7 +270,7 @@ def _handle_entity_update(snap: dict, event: dict) -> ReduceResult:
     return _ok(snap)
 
 
-def _handle_entity_remove(snap: dict, event: dict) -> ReduceResult:
+def _handle_entity_remove(snap: dict, event: dict) -> ApplyResult:
     ref = event.get("ref")
 
     if ref is None:
@@ -291,7 +289,7 @@ def _handle_entity_remove(snap: dict, event: dict) -> ReduceResult:
     return _ok(snap)
 
 
-def _handle_entity_move(snap: dict, event: dict) -> ReduceResult:
+def _handle_entity_move(snap: dict, event: dict) -> ApplyResult:
     ref = event.get("ref")
     new_parent = event.get("parent", "root")
     position = event.get("position")
@@ -352,7 +350,7 @@ def _get_descendants(snap: dict, entity_id: str) -> set[str]:
     return result
 
 
-def _handle_entity_reorder(snap: dict, event: dict) -> ReduceResult:
+def _handle_entity_reorder(snap: dict, event: dict) -> ApplyResult:
     ref = event.get("ref")
     new_children = event.get("children", [])
 
@@ -392,7 +390,7 @@ def _handle_entity_reorder(snap: dict, event: dict) -> ReduceResult:
 # ---------------------------------------------------------------------------
 
 
-def _handle_rel_set(snap: dict, event: dict) -> ReduceResult:
+def _handle_rel_set(snap: dict, event: dict) -> ApplyResult:
     from_id = event.get("from")
     to_id = event.get("to")
     rel_type = event.get("type")
@@ -446,7 +444,7 @@ def _handle_rel_set(snap: dict, event: dict) -> ReduceResult:
     return _ok(snap)
 
 
-def _handle_rel_remove(snap: dict, event: dict) -> ReduceResult:
+def _handle_rel_remove(snap: dict, event: dict) -> ApplyResult:
     from_id = event.get("from")
     to_id = event.get("to")
     rel_type = event.get("type")
@@ -465,7 +463,7 @@ def _handle_rel_remove(snap: dict, event: dict) -> ReduceResult:
     return _ok(snap)
 
 
-def _handle_rel_constrain(snap: dict, event: dict) -> ReduceResult:
+def _handle_rel_constrain(snap: dict, event: dict) -> ApplyResult:
     constraint_id = event.get("id")
     if constraint_id is None:
         return _reject(snap, "MISSING_ID: rel.constrain requires 'id'")
@@ -508,14 +506,14 @@ def _handle_rel_constrain(snap: dict, event: dict) -> ReduceResult:
 # ---------------------------------------------------------------------------
 
 
-def _handle_style_set(snap: dict, event: dict) -> ReduceResult:
+def _handle_style_set(snap: dict, event: dict) -> ApplyResult:
     props = event.get("p", {})
     snap["styles"]["global"].update(props)
     _inc(snap)
     return _ok(snap)
 
 
-def _handle_style_entity(snap: dict, event: dict) -> ReduceResult:
+def _handle_style_entity(snap: dict, event: dict) -> ApplyResult:
     ref = event.get("ref")
     props = event.get("p", {})
 
@@ -543,7 +541,7 @@ def _handle_style_entity(snap: dict, event: dict) -> ReduceResult:
 # ---------------------------------------------------------------------------
 
 
-def _handle_meta_set(snap: dict, event: dict) -> ReduceResult:
+def _handle_meta_set(snap: dict, event: dict) -> ApplyResult:
     # Support both {"t":"meta.set","p":{...}} and {"t":"meta.update","title":...} formats
     props = event.get("p", {})
     # Also check for direct properties (meta.update format from L3)
@@ -559,7 +557,7 @@ def _handle_meta_set(snap: dict, event: dict) -> ReduceResult:
     return _ok(snap)
 
 
-def _handle_meta_annotate(snap: dict, event: dict) -> ReduceResult:
+def _handle_meta_annotate(snap: dict, event: dict) -> ApplyResult:
     props = event.get("p", {})
     note = props.get("note", "")
     pinned = props.get("pinned", False)
@@ -576,7 +574,7 @@ def _handle_meta_annotate(snap: dict, event: dict) -> ReduceResult:
     return _ok(snap)
 
 
-def _handle_meta_constrain(snap: dict, event: dict) -> ReduceResult:
+def _handle_meta_constrain(snap: dict, event: dict) -> ApplyResult:
     constraint_id = event.get("id")
     if constraint_id is None:
         return _reject(snap, "MISSING_ID: meta.constrain requires 'id'")
@@ -618,7 +616,7 @@ def _handle_meta_constrain(snap: dict, event: dict) -> ReduceResult:
 # ---------------------------------------------------------------------------
 
 
-def _handle_voice(snap: dict, event: dict) -> ReduceResult:
+def _handle_voice(snap: dict, event: dict) -> ApplyResult:
     """Voice signal — pass through for chat display. No snapshot mutation."""
     signal = {
         "type": "voice",
@@ -627,7 +625,7 @@ def _handle_voice(snap: dict, event: dict) -> ReduceResult:
     return _ok(snap, signal=signal)
 
 
-def _handle_escalate(snap: dict, event: dict) -> ReduceResult:
+def _handle_escalate(snap: dict, event: dict) -> ApplyResult:
     """Escalate signal — pass through for tier routing. No snapshot mutation."""
     signal = {
         "type": "escalate",
@@ -638,13 +636,13 @@ def _handle_escalate(snap: dict, event: dict) -> ReduceResult:
     return _ok(snap, signal=signal)
 
 
-def _handle_batch_start(snap: dict, event: dict) -> ReduceResult:
+def _handle_batch_start(snap: dict, event: dict) -> ApplyResult:
     """Batch start signal. No snapshot mutation."""
     signal = {"type": "batch.start"}
     return _ok(snap, signal=signal)
 
 
-def _handle_batch_end(snap: dict, event: dict) -> ReduceResult:
+def _handle_batch_end(snap: dict, event: dict) -> ApplyResult:
     """Batch end signal. No snapshot mutation."""
     signal = {"type": "batch.end"}
     return _ok(snap, signal=signal)

--- a/engine/kernel/tests/test_entity.py
+++ b/engine/kernel/tests/test_entity.py
@@ -1,12 +1,12 @@
 """
-AIde Reducer — Entity Primitive Tests
+AIde Kernel — Entity Tests
 
 Tests for entity.create, entity.update, entity.remove, entity.move, entity.reorder.
 """
 
 import pytest
 
-from engine.kernel.reducer import empty_snapshot, reduce
+from engine.kernel import apply, empty_snapshot
 
 # ============================================================================
 # Fixtures
@@ -20,14 +20,14 @@ def empty():
 
 @pytest.fixture
 def state_with_parent(empty):
-    result = reduce(empty, {"t": "entity.create", "id": "guests", "display": "table", "p": {}})
+    result = apply(empty, {"t": "entity.create", "id": "guests", "display": "table", "p": {}})
     assert result.accepted
     return result.snapshot
 
 
 @pytest.fixture
 def state_with_entity(state_with_parent):
-    result = reduce(
+    result = apply(
         state_with_parent,
         {"t": "entity.create", "id": "guest_linda", "parent": "guests", "p": {"name": "Aunt Linda", "rsvp": "yes"}},
     )
@@ -39,7 +39,7 @@ def state_with_entity(state_with_parent):
 def state_with_three_children(state_with_parent):
     snap = state_with_parent
     for name in ["guest_alice", "guest_bob", "guest_carol"]:
-        result = reduce(snap, {"t": "entity.create", "id": name, "parent": "guests", "p": {"name": name}})
+        result = apply(snap, {"t": "entity.create", "id": name, "parent": "guests", "p": {"name": name}})
         assert result.accepted
         snap = result.snapshot
     return snap
@@ -52,7 +52,7 @@ def state_with_three_children(state_with_parent):
 
 class TestEntityCreate:
     def test_creates_root_entity(self, empty):
-        result = reduce(empty, {"t": "entity.create", "id": "page_home", "display": "page", "p": {"title": "Home"}})
+        result = apply(empty, {"t": "entity.create", "id": "page_home", "display": "page", "p": {"title": "Home"}})
         assert result.accepted
         entity = result.snapshot["entities"]["page_home"]
         assert entity["id"] == "page_home"
@@ -63,7 +63,7 @@ class TestEntityCreate:
         assert entity["_children"] == []
 
     def test_creates_child_entity(self, state_with_parent):
-        result = reduce(
+        result = apply(
             state_with_parent,
             {"t": "entity.create", "id": "guest_linda", "parent": "guests", "p": {"name": "Linda"}},
         )
@@ -75,19 +75,19 @@ class TestEntityCreate:
 
     def test_sequence_incremented(self, empty):
         assert empty["_sequence"] == 0
-        result = reduce(empty, {"t": "entity.create", "id": "e1", "p": {}})
+        result = apply(empty, {"t": "entity.create", "id": "e1", "p": {}})
         assert result.snapshot["_sequence"] == 1
-        result2 = reduce(result.snapshot, {"t": "entity.create", "id": "e2", "p": {}})
+        result2 = apply(result.snapshot, {"t": "entity.create", "id": "e2", "p": {}})
         assert result2.snapshot["_sequence"] == 2
 
     def test_created_seq_and_updated_seq_set(self, empty):
-        result = reduce(empty, {"t": "entity.create", "id": "e1", "p": {}})
+        result = apply(empty, {"t": "entity.create", "id": "e1", "p": {}})
         entity = result.snapshot["entities"]["e1"]
         assert entity["_created_seq"] == 1
         assert entity["_updated_seq"] == 1
 
     def test_props_stored_correctly(self, empty):
-        result = reduce(
+        result = apply(
             empty,
             {"t": "entity.create", "id": "item_1", "p": {"name": "Item", "done": False, "count": 5}},
         )
@@ -98,52 +98,52 @@ class TestEntityCreate:
         assert props["count"] == 5
 
     def test_reject_duplicate_id(self, state_with_entity):
-        result = reduce(state_with_entity, {"t": "entity.create", "id": "guest_linda", "p": {}})
+        result = apply(state_with_entity, {"t": "entity.create", "id": "guest_linda", "p": {}})
         assert not result.accepted
         assert "ENTITY_EXISTS" in result.reason
 
     def test_reject_missing_parent(self, empty):
-        result = reduce(empty, {"t": "entity.create", "id": "child", "parent": "nonexistent", "p": {}})
+        result = apply(empty, {"t": "entity.create", "id": "child", "parent": "nonexistent", "p": {}})
         assert not result.accepted
         assert "PARENT_NOT_FOUND" in result.reason
 
     def test_reject_invalid_id_uppercase(self, empty):
-        result = reduce(empty, {"t": "entity.create", "id": "GuestLinda", "p": {}})
+        result = apply(empty, {"t": "entity.create", "id": "GuestLinda", "p": {}})
         assert not result.accepted
         assert "INVALID_ID" in result.reason
 
     def test_reject_invalid_id_spaces(self, empty):
-        result = reduce(empty, {"t": "entity.create", "id": "guest linda", "p": {}})
+        result = apply(empty, {"t": "entity.create", "id": "guest linda", "p": {}})
         assert not result.accepted
         assert "INVALID_ID" in result.reason
 
     def test_reject_invalid_id_too_long(self, empty):
         long_id = "a" * 65
-        result = reduce(empty, {"t": "entity.create", "id": long_id, "p": {}})
+        result = apply(empty, {"t": "entity.create", "id": long_id, "p": {}})
         assert not result.accepted
         assert "INVALID_ID" in result.reason
 
     def test_reject_missing_id(self, empty):
-        result = reduce(empty, {"t": "entity.create", "p": {}})
+        result = apply(empty, {"t": "entity.create", "p": {}})
         assert not result.accepted
         assert "MISSING_ID" in result.reason
 
     def test_default_parent_is_root(self, empty):
-        result = reduce(empty, {"t": "entity.create", "id": "top_level", "p": {}})
+        result = apply(empty, {"t": "entity.create", "id": "top_level", "p": {}})
         assert result.accepted
         assert result.snapshot["entities"]["top_level"]["parent"] == "root"
 
     def test_display_can_be_none(self, empty):
-        result = reduce(empty, {"t": "entity.create", "id": "e1", "p": {}})
+        result = apply(empty, {"t": "entity.create", "id": "e1", "p": {}})
         assert result.accepted
         assert result.snapshot["entities"]["e1"]["display"] is None
 
     def test_reject_removed_parent(self, state_with_parent):
         # Remove parent
-        result = reduce(state_with_parent, {"t": "entity.remove", "ref": "guests"})
+        result = apply(state_with_parent, {"t": "entity.remove", "ref": "guests"})
         assert result.accepted
         # Now try to create child under removed parent
-        result2 = reduce(result.snapshot, {"t": "entity.create", "id": "new_child", "parent": "guests", "p": {}})
+        result2 = apply(result.snapshot, {"t": "entity.create", "id": "new_child", "parent": "guests", "p": {}})
         assert not result2.accepted
         assert "PARENT_NOT_FOUND" in result2.reason
 
@@ -155,7 +155,7 @@ class TestEntityCreate:
 
 class TestEntityUpdate:
     def test_merges_props(self, state_with_entity):
-        result = reduce(
+        result = apply(
             state_with_entity,
             {"t": "entity.update", "ref": "guest_linda", "p": {"rsvp": "confirmed", "dietary": "vegetarian"}},
         )
@@ -167,18 +167,18 @@ class TestEntityUpdate:
 
     def test_updated_seq_incremented(self, state_with_entity):
         old_seq = state_with_entity["entities"]["guest_linda"]["_updated_seq"]
-        result = reduce(state_with_entity, {"t": "entity.update", "ref": "guest_linda", "p": {"rsvp": "no"}})
+        result = apply(state_with_entity, {"t": "entity.update", "ref": "guest_linda", "p": {"rsvp": "no"}})
         assert result.accepted
         new_seq = result.snapshot["entities"]["guest_linda"]["_updated_seq"]
         assert new_seq > old_seq
 
     def test_new_prop_extends_entity(self, state_with_entity):
-        result = reduce(state_with_entity, {"t": "entity.update", "ref": "guest_linda", "p": {"table": "Table 1"}})
+        result = apply(state_with_entity, {"t": "entity.update", "ref": "guest_linda", "p": {"table": "Table 1"}})
         assert result.accepted
         assert result.snapshot["entities"]["guest_linda"]["props"]["table"] == "Table 1"
 
     def test_multiple_props_in_one_update(self, state_with_entity):
-        result = reduce(
+        result = apply(
             state_with_entity,
             {"t": "entity.update", "ref": "guest_linda", "p": {"a": 1, "b": 2, "c": 3}},
         )
@@ -187,18 +187,18 @@ class TestEntityUpdate:
         assert props["a"] == 1 and props["b"] == 2 and props["c"] == 3
 
     def test_reject_nonexistent_entity(self, empty):
-        result = reduce(empty, {"t": "entity.update", "ref": "nobody", "p": {"x": 1}})
+        result = apply(empty, {"t": "entity.update", "ref": "nobody", "p": {"x": 1}})
         assert not result.accepted
         assert "ENTITY_NOT_FOUND" in result.reason
 
     def test_reject_removed_entity(self, state_with_entity):
-        remove_result = reduce(state_with_entity, {"t": "entity.remove", "ref": "guest_linda"})
-        result = reduce(remove_result.snapshot, {"t": "entity.update", "ref": "guest_linda", "p": {"x": 1}})
+        remove_result = apply(state_with_entity, {"t": "entity.remove", "ref": "guest_linda"})
+        result = apply(remove_result.snapshot, {"t": "entity.update", "ref": "guest_linda", "p": {"x": 1}})
         assert not result.accepted
         assert "ENTITY_NOT_FOUND" in result.reason
 
     def test_reject_missing_ref(self, empty):
-        result = reduce(empty, {"t": "entity.update", "p": {"x": 1}})
+        result = apply(empty, {"t": "entity.update", "p": {"x": 1}})
         assert not result.accepted
         assert "MISSING_REF" in result.reason
 
@@ -210,7 +210,7 @@ class TestEntityUpdate:
 
 class TestEntityRemove:
     def test_soft_deletes_entity(self, state_with_entity):
-        result = reduce(state_with_entity, {"t": "entity.remove", "ref": "guest_linda"})
+        result = apply(state_with_entity, {"t": "entity.remove", "ref": "guest_linda"})
         assert result.accepted
         entity = result.snapshot["entities"]["guest_linda"]
         assert entity["_removed"] is True
@@ -221,10 +221,10 @@ class TestEntityRemove:
         # Add children
         snap = state_with_parent
         for child_id in ["c1", "c2", "c3"]:
-            result = reduce(snap, {"t": "entity.create", "id": child_id, "parent": "guests", "p": {}})
+            result = apply(snap, {"t": "entity.create", "id": child_id, "parent": "guests", "p": {}})
             snap = result.snapshot
         # Remove parent
-        result = reduce(snap, {"t": "entity.remove", "ref": "guests"})
+        result = apply(snap, {"t": "entity.remove", "ref": "guests"})
         assert result.accepted
         # All children removed
         for child_id in ["c1", "c2", "c3"]:
@@ -234,26 +234,26 @@ class TestEntityRemove:
         snap = empty
         # Create grandparent → parent → child
         for eid, parent in [("gp", "root"), ("p1", "gp"), ("c1", "p1")]:
-            result = reduce(snap, {"t": "entity.create", "id": eid, "parent": parent, "p": {}})
+            result = apply(snap, {"t": "entity.create", "id": eid, "parent": parent, "p": {}})
             snap = result.snapshot
-        result = reduce(snap, {"t": "entity.remove", "ref": "gp"})
+        result = apply(snap, {"t": "entity.remove", "ref": "gp"})
         assert result.accepted
         for eid in ["gp", "p1", "c1"]:
             assert result.snapshot["entities"][eid]["_removed"] is True
 
     def test_reject_nonexistent_entity(self, empty):
-        result = reduce(empty, {"t": "entity.remove", "ref": "nobody"})
+        result = apply(empty, {"t": "entity.remove", "ref": "nobody"})
         assert not result.accepted
         assert "ENTITY_NOT_FOUND" in result.reason
 
     def test_reject_already_removed(self, state_with_entity):
-        result = reduce(state_with_entity, {"t": "entity.remove", "ref": "guest_linda"})
-        result2 = reduce(result.snapshot, {"t": "entity.remove", "ref": "guest_linda"})
+        result = apply(state_with_entity, {"t": "entity.remove", "ref": "guest_linda"})
+        result2 = apply(result.snapshot, {"t": "entity.remove", "ref": "guest_linda"})
         assert not result2.accepted
         assert "ALREADY_REMOVED" in result2.reason
 
     def test_reject_missing_ref(self, empty):
-        result = reduce(empty, {"t": "entity.remove"})
+        result = apply(empty, {"t": "entity.remove"})
         assert not result.accepted
         assert "MISSING_REF" in result.reason
 
@@ -267,10 +267,10 @@ class TestEntityMove:
     def test_move_to_different_parent(self, empty):
         snap = empty
         for eid, parent in [("section_a", "root"), ("section_b", "root"), ("item_x", "section_a")]:
-            result = reduce(snap, {"t": "entity.create", "id": eid, "parent": parent, "p": {}})
+            result = apply(snap, {"t": "entity.create", "id": eid, "parent": parent, "p": {}})
             snap = result.snapshot
 
-        result = reduce(snap, {"t": "entity.move", "ref": "item_x", "parent": "section_b"})
+        result = apply(snap, {"t": "entity.move", "ref": "item_x", "parent": "section_b"})
         assert result.accepted
         assert result.snapshot["entities"]["item_x"]["parent"] == "section_b"
         assert "item_x" not in result.snapshot["entities"]["section_a"]["_children"]
@@ -279,47 +279,47 @@ class TestEntityMove:
     def test_move_with_position(self, state_with_three_children):
         snap = state_with_three_children
         # Add a separate parent and move guest_bob to it at position 0
-        result = reduce(snap, {"t": "entity.create", "id": "vip_section", "p": {}})
+        result = apply(snap, {"t": "entity.create", "id": "vip_section", "p": {}})
         snap = result.snapshot
-        result = reduce(snap, {"t": "entity.move", "ref": "guest_bob", "parent": "vip_section", "position": 0})
+        result = apply(snap, {"t": "entity.move", "ref": "guest_bob", "parent": "vip_section", "position": 0})
         assert result.accepted
         assert result.snapshot["entities"]["vip_section"]["_children"][0] == "guest_bob"
 
     def test_move_to_end_without_position(self, empty):
         snap = empty
         for eid, parent in [("sect_a", "root"), ("sect_b", "root"), ("item_1", "sect_a")]:
-            result = reduce(snap, {"t": "entity.create", "id": eid, "parent": parent, "p": {}})
+            result = apply(snap, {"t": "entity.create", "id": eid, "parent": parent, "p": {}})
             snap = result.snapshot
-        result = reduce(snap, {"t": "entity.move", "ref": "item_1", "parent": "sect_b"})
+        result = apply(snap, {"t": "entity.move", "ref": "item_1", "parent": "sect_b"})
         assert result.accepted
         assert result.snapshot["entities"]["sect_b"]["_children"][-1] == "item_1"
 
     def test_reject_nonexistent_entity(self, state_with_parent):
-        result = reduce(state_with_parent, {"t": "entity.move", "ref": "nobody", "parent": "guests"})
+        result = apply(state_with_parent, {"t": "entity.move", "ref": "nobody", "parent": "guests"})
         assert not result.accepted
         assert "ENTITY_NOT_FOUND" in result.reason
 
     def test_reject_nonexistent_parent(self, state_with_entity):
-        result = reduce(state_with_entity, {"t": "entity.move", "ref": "guest_linda", "parent": "nosuchparent"})
+        result = apply(state_with_entity, {"t": "entity.move", "ref": "guest_linda", "parent": "nosuchparent"})
         assert not result.accepted
         assert "PARENT_NOT_FOUND" in result.reason
 
     def test_reject_move_to_self(self, state_with_entity):
-        result = reduce(state_with_entity, {"t": "entity.move", "ref": "guest_linda", "parent": "guest_linda"})
+        result = apply(state_with_entity, {"t": "entity.move", "ref": "guest_linda", "parent": "guest_linda"})
         assert not result.accepted
         assert "CYCLE" in result.reason
 
     def test_reject_move_to_own_descendant(self, empty):
         snap = empty
         for eid, parent in [("gp", "root"), ("child", "gp")]:
-            result = reduce(snap, {"t": "entity.create", "id": eid, "parent": parent, "p": {}})
+            result = apply(snap, {"t": "entity.create", "id": eid, "parent": parent, "p": {}})
             snap = result.snapshot
-        result = reduce(snap, {"t": "entity.move", "ref": "gp", "parent": "child"})
+        result = apply(snap, {"t": "entity.move", "ref": "gp", "parent": "child"})
         assert not result.accepted
         assert "CYCLE" in result.reason
 
     def test_reject_missing_ref(self, empty):
-        result = reduce(empty, {"t": "entity.move", "parent": "root"})
+        result = apply(empty, {"t": "entity.move", "parent": "root"})
         assert not result.accepted
         assert "MISSING_REF" in result.reason
 
@@ -332,7 +332,7 @@ class TestEntityMove:
 class TestEntityReorder:
     def test_reorders_children(self, state_with_three_children):
         snap = state_with_three_children
-        result = reduce(
+        result = apply(
             snap,
             {"t": "entity.reorder", "ref": "guests", "children": ["guest_carol", "guest_alice", "guest_bob"]},
         )
@@ -341,7 +341,7 @@ class TestEntityReorder:
         assert children[:3] == ["guest_carol", "guest_alice", "guest_bob"]
 
     def test_reject_missing_children(self, state_with_three_children):
-        result = reduce(
+        result = apply(
             state_with_three_children,
             {"t": "entity.reorder", "ref": "guests", "children": ["guest_alice", "guest_bob"]},  # missing carol
         )
@@ -349,7 +349,7 @@ class TestEntityReorder:
         assert "REORDER_MISMATCH" in result.reason
 
     def test_reject_extra_children(self, state_with_three_children):
-        result = reduce(
+        result = apply(
             state_with_three_children,
             {"t": "entity.reorder", "ref": "guests", "children": ["guest_alice", "guest_bob", "guest_carol", "extra"]},
         )
@@ -359,18 +359,18 @@ class TestEntityReorder:
     def test_removed_children_excluded_from_required_set(self, state_with_three_children):
         snap = state_with_three_children
         # Remove one child
-        result = reduce(snap, {"t": "entity.remove", "ref": "guest_carol"})
+        result = apply(snap, {"t": "entity.remove", "ref": "guest_carol"})
         snap = result.snapshot
         # Reorder without removed child — should work
-        result = reduce(snap, {"t": "entity.reorder", "ref": "guests", "children": ["guest_bob", "guest_alice"]})
+        result = apply(snap, {"t": "entity.reorder", "ref": "guests", "children": ["guest_bob", "guest_alice"]})
         assert result.accepted
 
     def test_reject_nonexistent_entity(self, empty):
-        result = reduce(empty, {"t": "entity.reorder", "ref": "nobody", "children": []})
+        result = apply(empty, {"t": "entity.reorder", "ref": "nobody", "children": []})
         assert not result.accepted
         assert "ENTITY_NOT_FOUND" in result.reason
 
     def test_reject_missing_ref(self, empty):
-        result = reduce(empty, {"t": "entity.reorder", "children": []})
+        result = apply(empty, {"t": "entity.reorder", "children": []})
         assert not result.accepted
         assert "MISSING_REF" in result.reason

--- a/engine/kernel/tests/test_kernel_api.py
+++ b/engine/kernel/tests/test_kernel_api.py
@@ -1,0 +1,37 @@
+"""
+TDD test for kernel API rename.
+
+Tests the renamed kernel API: apply() instead of reduce().
+"""
+
+import pytest
+
+from engine.kernel import apply, empty_snapshot, ApplyResult
+
+
+class TestKernelAPI:
+    """Tests for the renamed kernel API."""
+
+    def test_apply_entity_create(self):
+        """apply() creates an entity in the snapshot."""
+        snap = empty_snapshot()
+        event = {"t": "entity.create", "id": "test_entity", "p": {"name": "Test"}}
+        result = apply(snap, event)
+        assert result.accepted
+        assert "test_entity" in result.snapshot["entities"]
+
+    def test_apply_returns_reduce_result(self):
+        """apply() returns a result with snapshot and accepted flag."""
+        snap = empty_snapshot()
+        event = {"t": "entity.create", "id": "item", "p": {}}
+        result = apply(snap, event)
+        assert hasattr(result, "snapshot")
+        assert hasattr(result, "accepted")
+
+    def test_empty_snapshot_still_works(self):
+        """empty_snapshot() is unchanged."""
+        snap = empty_snapshot()
+        assert "entities" in snap
+        assert "relationships" in snap
+        assert "styles" in snap
+        assert "meta" in snap

--- a/engine/kernel/tests/test_relationship.py
+++ b/engine/kernel/tests/test_relationship.py
@@ -1,12 +1,12 @@
 """
-AIde Reducer — Relationship Primitive Tests
+AIde Kernel — Relationship Tests
 
 Tests for rel.set, rel.remove, rel.constrain.
 """
 
 import pytest
 
-from engine.kernel.reducer import empty_snapshot, reduce
+from engine.kernel import apply, empty_snapshot
 
 # ============================================================================
 # Fixtures
@@ -22,7 +22,7 @@ def empty():
 def state_with_two_entities(empty):
     snap = empty
     for eid in ["entity_a", "entity_b"]:
-        result = reduce(snap, {"t": "entity.create", "id": eid, "p": {"name": eid}})
+        result = apply(snap, {"t": "entity.create", "id": eid, "p": {"name": eid}})
         assert result.accepted
         snap = result.snapshot
     return snap
@@ -32,7 +32,7 @@ def state_with_two_entities(empty):
 def state_with_three_entities(empty):
     snap = empty
     for eid in ["entity_a", "entity_b", "entity_c"]:
-        result = reduce(snap, {"t": "entity.create", "id": eid, "p": {"name": eid}})
+        result = apply(snap, {"t": "entity.create", "id": eid, "p": {"name": eid}})
         assert result.accepted
         snap = result.snapshot
     return snap
@@ -45,7 +45,7 @@ def state_with_three_entities(empty):
 
 class TestRelSet:
     def test_creates_new_relationship(self, state_with_two_entities):
-        result = reduce(
+        result = apply(
             state_with_two_entities,
             {"t": "rel.set", "from": "entity_a", "to": "entity_b", "type": "knows", "cardinality": "many_to_many"},
         )
@@ -57,7 +57,7 @@ class TestRelSet:
         assert rels[0]["type"] == "knows"
 
     def test_cardinality_persisted_on_first_set(self, state_with_two_entities):
-        result = reduce(
+        result = apply(
             state_with_two_entities,
             {"t": "rel.set", "from": "entity_a", "to": "entity_b", "type": "leads", "cardinality": "many_to_one"},
         )
@@ -67,13 +67,13 @@ class TestRelSet:
     def test_many_to_one_auto_removes_old_link(self, state_with_three_entities):
         snap = state_with_three_entities
         # entity_a → entity_b (many_to_one)
-        result = reduce(
+        result = apply(
             snap,
             {"t": "rel.set", "from": "entity_a", "to": "entity_b", "type": "reports_to", "cardinality": "many_to_one"},
         )
         snap = result.snapshot
         # entity_a → entity_c (should replace entity_b)
-        result = reduce(snap, {"t": "rel.set", "from": "entity_a", "to": "entity_c", "type": "reports_to"})
+        result = apply(snap, {"t": "rel.set", "from": "entity_a", "to": "entity_c", "type": "reports_to"})
         assert result.accepted
         rels = [r for r in result.snapshot["relationships"] if r["type"] == "reports_to"]
         assert len(rels) == 1
@@ -82,12 +82,12 @@ class TestRelSet:
     def test_one_to_one_auto_removes_both_sides(self, state_with_three_entities):
         snap = state_with_three_entities
         # entity_a ↔ entity_b (one_to_one)
-        result = reduce(
+        result = apply(
             snap, {"t": "rel.set", "from": "entity_a", "to": "entity_b", "type": "partner", "cardinality": "one_to_one"}
         )
         snap = result.snapshot
         # entity_c → entity_b (should replace entity_a's link)
-        result = reduce(snap, {"t": "rel.set", "from": "entity_c", "to": "entity_b", "type": "partner"})
+        result = apply(snap, {"t": "rel.set", "from": "entity_c", "to": "entity_b", "type": "partner"})
         assert result.accepted
         rels = [r for r in result.snapshot["relationships"] if r["type"] == "partner"]
         assert len(rels) == 1
@@ -96,17 +96,17 @@ class TestRelSet:
 
     def test_many_to_many_allows_multiple_links(self, state_with_three_entities):
         snap = state_with_three_entities
-        result = reduce(
+        result = apply(
             snap, {"t": "rel.set", "from": "entity_a", "to": "entity_b", "type": "likes", "cardinality": "many_to_many"}
         )
         snap = result.snapshot
-        result = reduce(snap, {"t": "rel.set", "from": "entity_a", "to": "entity_c", "type": "likes"})
+        result = apply(snap, {"t": "rel.set", "from": "entity_a", "to": "entity_c", "type": "likes"})
         assert result.accepted
         rels = [r for r in result.snapshot["relationships"] if r["type"] == "likes"]
         assert len(rels) == 2
 
     def test_reject_from_entity_not_found(self, state_with_two_entities):
-        result = reduce(
+        result = apply(
             state_with_two_entities,
             {"t": "rel.set", "from": "nobody", "to": "entity_b", "type": "x"},
         )
@@ -114,7 +114,7 @@ class TestRelSet:
         assert "ENTITY_NOT_FOUND" in result.reason
 
     def test_reject_to_entity_not_found(self, state_with_two_entities):
-        result = reduce(
+        result = apply(
             state_with_two_entities,
             {"t": "rel.set", "from": "entity_a", "to": "nobody", "type": "x"},
         )
@@ -122,29 +122,29 @@ class TestRelSet:
         assert "ENTITY_NOT_FOUND" in result.reason
 
     def test_reject_missing_from(self, state_with_two_entities):
-        result = reduce(state_with_two_entities, {"t": "rel.set", "to": "entity_b", "type": "x"})
+        result = apply(state_with_two_entities, {"t": "rel.set", "to": "entity_b", "type": "x"})
         assert not result.accepted
         assert "MISSING_FROM" in result.reason
 
     def test_reject_missing_to(self, state_with_two_entities):
-        result = reduce(state_with_two_entities, {"t": "rel.set", "from": "entity_a", "type": "x"})
+        result = apply(state_with_two_entities, {"t": "rel.set", "from": "entity_a", "type": "x"})
         assert not result.accepted
         assert "MISSING_TO" in result.reason
 
     def test_reject_missing_type(self, state_with_two_entities):
-        result = reduce(state_with_two_entities, {"t": "rel.set", "from": "entity_a", "to": "entity_b"})
+        result = apply(state_with_two_entities, {"t": "rel.set", "from": "entity_a", "to": "entity_b"})
         assert not result.accepted
         assert "MISSING_TYPE" in result.reason
 
     def test_existing_cardinality_used_not_overridden(self, state_with_three_entities):
         snap = state_with_three_entities
         # First set establishes many_to_one
-        result = reduce(
+        result = apply(
             snap, {"t": "rel.set", "from": "entity_a", "to": "entity_b", "type": "owns", "cardinality": "many_to_one"}
         )
         snap = result.snapshot
         # Second set tries many_to_many — should use stored many_to_one
-        result = reduce(
+        result = apply(
             snap, {"t": "rel.set", "from": "entity_a", "to": "entity_c", "type": "owns", "cardinality": "many_to_many"}
         )
         assert result.accepted
@@ -162,16 +162,16 @@ class TestRelSet:
 class TestRelRemove:
     def test_removes_existing_relationship(self, state_with_two_entities):
         snap = state_with_two_entities
-        result = reduce(snap, {"t": "rel.set", "from": "entity_a", "to": "entity_b", "type": "likes"})
+        result = apply(snap, {"t": "rel.set", "from": "entity_a", "to": "entity_b", "type": "likes"})
         snap = result.snapshot
         assert len(snap["relationships"]) == 1
 
-        result = reduce(snap, {"t": "rel.remove", "from": "entity_a", "to": "entity_b", "type": "likes"})
+        result = apply(snap, {"t": "rel.remove", "from": "entity_a", "to": "entity_b", "type": "likes"})
         assert result.accepted
         assert len(result.snapshot["relationships"]) == 0
 
     def test_no_op_if_relationship_doesnt_exist(self, state_with_two_entities):
-        result = reduce(
+        result = apply(
             state_with_two_entities,
             {"t": "rel.remove", "from": "entity_a", "to": "entity_b", "type": "nonexistent"},
         )
@@ -179,15 +179,15 @@ class TestRelRemove:
 
     def test_removes_only_matching_relationship(self, state_with_three_entities):
         snap = state_with_three_entities
-        result = reduce(
+        result = apply(
             snap, {"t": "rel.set", "from": "entity_a", "to": "entity_b", "type": "x", "cardinality": "many_to_many"}
         )
         snap = result.snapshot
-        result = reduce(snap, {"t": "rel.set", "from": "entity_a", "to": "entity_c", "type": "x"})
+        result = apply(snap, {"t": "rel.set", "from": "entity_a", "to": "entity_c", "type": "x"})
         snap = result.snapshot
         assert len(snap["relationships"]) == 2
 
-        result = reduce(snap, {"t": "rel.remove", "from": "entity_a", "to": "entity_b", "type": "x"})
+        result = apply(snap, {"t": "rel.remove", "from": "entity_a", "to": "entity_b", "type": "x"})
         assert result.accepted
         rels = result.snapshot["relationships"]
         assert len(rels) == 1
@@ -201,7 +201,7 @@ class TestRelRemove:
 
 class TestRelConstrain:
     def test_add_constraint(self, state_with_two_entities):
-        result = reduce(
+        result = apply(
             state_with_two_entities,
             {
                 "t": "rel.constrain",
@@ -222,16 +222,16 @@ class TestRelConstrain:
     def test_strict_constraint_rejects_violating_state(self, state_with_three_entities):
         snap = state_with_three_entities
         # Set up entity_a and entity_b both pointing to entity_c
-        result = reduce(
+        result = apply(
             snap,
             {"t": "rel.set", "from": "entity_a", "to": "entity_c", "type": "seated_at", "cardinality": "many_to_many"},
         )
         snap = result.snapshot
-        result = reduce(snap, {"t": "rel.set", "from": "entity_b", "to": "entity_c", "type": "seated_at"})
+        result = apply(snap, {"t": "rel.set", "from": "entity_b", "to": "entity_c", "type": "seated_at"})
         snap = result.snapshot
 
         # Now add strict constraint that they can't share the same target
-        result = reduce(
+        result = apply(
             snap,
             {
                 "t": "rel.constrain",
@@ -248,15 +248,15 @@ class TestRelConstrain:
     def test_non_strict_constraint_adds_without_rejecting(self, state_with_three_entities):
         snap = state_with_three_entities
         # Even if state "violates" non-strict constraint, it's allowed
-        result = reduce(
+        result = apply(
             snap,
             {"t": "rel.set", "from": "entity_a", "to": "entity_c", "type": "seated_at", "cardinality": "many_to_many"},
         )
         snap = result.snapshot
-        result = reduce(snap, {"t": "rel.set", "from": "entity_b", "to": "entity_c", "type": "seated_at"})
+        result = apply(snap, {"t": "rel.set", "from": "entity_b", "to": "entity_c", "type": "seated_at"})
         snap = result.snapshot
 
-        result = reduce(
+        result = apply(
             snap,
             {
                 "t": "rel.constrain",
@@ -270,7 +270,7 @@ class TestRelConstrain:
         assert result.accepted
 
     def test_reject_missing_id(self, state_with_two_entities):
-        result = reduce(
+        result = apply(
             state_with_two_entities,
             {"t": "rel.constrain", "rule": "exclude_pair"},
         )

--- a/engine/kernel/tests/test_style_meta_signals.py
+++ b/engine/kernel/tests/test_style_meta_signals.py
@@ -1,5 +1,5 @@
 """
-AIde Reducer — Style, Meta, and Signal Tests
+AIde Kernel — Style, Meta, and Signal Tests
 
 Tests for style.set, style.entity, meta.set, meta.annotate, meta.constrain,
 voice, escalate, and batch signals.
@@ -7,7 +7,7 @@ voice, escalate, and batch signals.
 
 import pytest
 
-from engine.kernel.reducer import empty_snapshot, reduce
+from engine.kernel import apply, empty_snapshot
 
 # ============================================================================
 # Fixtures
@@ -21,7 +21,7 @@ def empty():
 
 @pytest.fixture
 def state_with_entity(empty):
-    result = reduce(empty, {"t": "entity.create", "id": "item_one", "p": {"name": "Item One"}})
+    result = apply(empty, {"t": "entity.create", "id": "item_one", "p": {"name": "Item One"}})
     assert result.accepted
     return result.snapshot
 
@@ -33,7 +33,7 @@ def state_with_entity(empty):
 
 class TestStyleSet:
     def test_sets_global_styles(self, empty):
-        result = reduce(
+        result = apply(
             empty,
             {"t": "style.set", "p": {"primary_color": "#2D2D2A", "font_family": "Inter", "density": "comfortable"}},
         )
@@ -44,20 +44,20 @@ class TestStyleSet:
         assert styles["density"] == "comfortable"
 
     def test_merges_with_existing_styles(self, empty):
-        result = reduce(empty, {"t": "style.set", "p": {"primary_color": "#fff"}})
+        result = apply(empty, {"t": "style.set", "p": {"primary_color": "#fff"}})
         snap = result.snapshot
-        result = reduce(snap, {"t": "style.set", "p": {"font_family": "Georgia"}})
+        result = apply(snap, {"t": "style.set", "p": {"font_family": "Georgia"}})
         assert result.accepted
         styles = result.snapshot["styles"]["global"]
         assert styles["primary_color"] == "#fff"  # Preserved
         assert styles["font_family"] == "Georgia"  # Added
 
     def test_increments_sequence(self, empty):
-        result = reduce(empty, {"t": "style.set", "p": {"x": 1}})
+        result = apply(empty, {"t": "style.set", "p": {"x": 1}})
         assert result.snapshot["_sequence"] == 1
 
     def test_empty_props_ok(self, empty):
-        result = reduce(empty, {"t": "style.set", "p": {}})
+        result = apply(empty, {"t": "style.set", "p": {}})
         assert result.accepted
 
 
@@ -68,7 +68,7 @@ class TestStyleSet:
 
 class TestStyleEntity:
     def test_sets_entity_styles(self, state_with_entity):
-        result = reduce(
+        result = apply(
             state_with_entity,
             {"t": "style.entity", "ref": "item_one", "p": {"highlight": True, "color": "#e53e3e"}},
         )
@@ -80,28 +80,28 @@ class TestStyleEntity:
         assert result.snapshot["styles"]["entities"]["item_one"]["highlight"] is True
 
     def test_merges_entity_styles(self, state_with_entity):
-        result = reduce(state_with_entity, {"t": "style.entity", "ref": "item_one", "p": {"a": 1}})
+        result = apply(state_with_entity, {"t": "style.entity", "ref": "item_one", "p": {"a": 1}})
         snap = result.snapshot
-        result = reduce(snap, {"t": "style.entity", "ref": "item_one", "p": {"b": 2}})
+        result = apply(snap, {"t": "style.entity", "ref": "item_one", "p": {"b": 2}})
         assert result.accepted
         entity = result.snapshot["entities"]["item_one"]
         assert entity["_styles"]["a"] == 1
         assert entity["_styles"]["b"] == 2
 
     def test_reject_nonexistent_entity(self, empty):
-        result = reduce(empty, {"t": "style.entity", "ref": "nobody", "p": {"x": 1}})
+        result = apply(empty, {"t": "style.entity", "ref": "nobody", "p": {"x": 1}})
         assert not result.accepted
         assert "ENTITY_NOT_FOUND" in result.reason
 
     def test_reject_missing_ref(self, empty):
-        result = reduce(empty, {"t": "style.entity", "p": {"x": 1}})
+        result = apply(empty, {"t": "style.entity", "p": {"x": 1}})
         assert not result.accepted
         assert "MISSING_REF" in result.reason
 
     def test_reject_removed_entity(self, state_with_entity):
-        result = reduce(state_with_entity, {"t": "entity.remove", "ref": "item_one"})
+        result = apply(state_with_entity, {"t": "entity.remove", "ref": "item_one"})
         snap = result.snapshot
-        result = reduce(snap, {"t": "style.entity", "ref": "item_one", "p": {"x": 1}})
+        result = apply(snap, {"t": "style.entity", "ref": "item_one", "p": {"x": 1}})
         assert not result.accepted
         assert "ENTITY_NOT_FOUND" in result.reason
 
@@ -113,24 +113,24 @@ class TestStyleEntity:
 
 class TestMetaSet:
     def test_sets_title(self, empty):
-        result = reduce(empty, {"t": "meta.set", "p": {"title": "Sophie's Graduation Party"}})
+        result = apply(empty, {"t": "meta.set", "p": {"title": "Sophie's Graduation Party"}})
         assert result.accepted
         assert result.snapshot["meta"]["title"] == "Sophie's Graduation Party"
 
     def test_sets_identity(self, empty):
-        result = reduce(empty, {"t": "meta.set", "p": {"identity": "graduation_coordinator"}})
+        result = apply(empty, {"t": "meta.set", "p": {"identity": "graduation_coordinator"}})
         assert result.accepted
         assert result.snapshot["meta"]["identity"] == "graduation_coordinator"
 
     def test_updates_existing_meta(self, empty):
-        result = reduce(empty, {"t": "meta.set", "p": {"title": "Old Title"}})
+        result = apply(empty, {"t": "meta.set", "p": {"title": "Old Title"}})
         snap = result.snapshot
-        result = reduce(snap, {"t": "meta.set", "p": {"title": "New Title"}})
+        result = apply(snap, {"t": "meta.set", "p": {"title": "New Title"}})
         assert result.accepted
         assert result.snapshot["meta"]["title"] == "New Title"
 
     def test_sets_both_title_and_identity(self, empty):
-        result = reduce(
+        result = apply(
             empty,
             {"t": "meta.set", "p": {"title": "My Aide", "identity": "some_context"}},
         )
@@ -139,12 +139,12 @@ class TestMetaSet:
         assert result.snapshot["meta"]["identity"] == "some_context"
 
     def test_extra_meta_fields_stored(self, empty):
-        result = reduce(empty, {"t": "meta.set", "p": {"custom_field": "value"}})
+        result = apply(empty, {"t": "meta.set", "p": {"custom_field": "value"}})
         assert result.accepted
         assert result.snapshot["meta"]["custom_field"] == "value"
 
     def test_increments_sequence(self, empty):
-        result = reduce(empty, {"t": "meta.set", "p": {"title": "x"}})
+        result = apply(empty, {"t": "meta.set", "p": {"title": "x"}})
         assert result.snapshot["_sequence"] == 1
 
 
@@ -155,7 +155,7 @@ class TestMetaSet:
 
 class TestMetaAnnotate:
     def test_adds_annotation(self, empty):
-        result = reduce(empty, {"t": "meta.annotate", "p": {"note": "Guest count updated.", "pinned": False}})
+        result = apply(empty, {"t": "meta.annotate", "p": {"note": "Guest count updated.", "pinned": False}})
         assert result.accepted
         annotations = result.snapshot["meta"]["annotations"]
         assert len(annotations) == 1
@@ -163,12 +163,12 @@ class TestMetaAnnotate:
         assert annotations[0]["pinned"] is False
 
     def test_pinned_annotation(self, empty):
-        result = reduce(empty, {"t": "meta.annotate", "p": {"note": "Important!", "pinned": True}})
+        result = apply(empty, {"t": "meta.annotate", "p": {"note": "Important!", "pinned": True}})
         assert result.accepted
         assert result.snapshot["meta"]["annotations"][0]["pinned"] is True
 
     def test_annotation_has_ts_and_seq(self, empty):
-        result = reduce(empty, {"t": "meta.annotate", "p": {"note": "Note", "pinned": False}})
+        result = apply(empty, {"t": "meta.annotate", "p": {"note": "Note", "pinned": False}})
         annotation = result.snapshot["meta"]["annotations"][0]
         assert "ts" in annotation
         assert "seq" in annotation
@@ -176,7 +176,7 @@ class TestMetaAnnotate:
     def test_multiple_annotations_appended(self, empty):
         snap = empty
         for i in range(3):
-            result = reduce(snap, {"t": "meta.annotate", "p": {"note": f"Note {i}", "pinned": False}})
+            result = apply(snap, {"t": "meta.annotate", "p": {"note": f"Note {i}", "pinned": False}})
             snap = result.snapshot
         assert len(snap["meta"]["annotations"]) == 3
         assert snap["meta"]["annotations"][2]["note"] == "Note 2"
@@ -190,9 +190,9 @@ class TestMetaAnnotate:
 class TestMetaConstrain:
     def test_adds_structural_constraint(self, empty):
         snap = empty
-        result = reduce(snap, {"t": "entity.create", "id": "guests", "p": {}})
+        result = apply(snap, {"t": "entity.create", "id": "guests", "p": {}})
         snap = result.snapshot
-        result = reduce(
+        result = apply(
             snap,
             {
                 "t": "meta.constrain",
@@ -211,15 +211,15 @@ class TestMetaConstrain:
 
     def test_strict_constraint_rejects_violating_state(self, empty):
         snap = empty
-        result = reduce(snap, {"t": "entity.create", "id": "guests", "p": {}})
+        result = apply(snap, {"t": "entity.create", "id": "guests", "p": {}})
         snap = result.snapshot
         # Add 3 children
         for i in range(3):
-            result = reduce(snap, {"t": "entity.create", "id": f"guest_{i}", "parent": "guests", "p": {}})
+            result = apply(snap, {"t": "entity.create", "id": f"guest_{i}", "parent": "guests", "p": {}})
             snap = result.snapshot
 
         # Strict max_children = 2, but we have 3
-        result = reduce(
+        result = apply(
             snap,
             {
                 "t": "meta.constrain",
@@ -235,13 +235,13 @@ class TestMetaConstrain:
 
     def test_non_strict_constraint_with_violation_accepted(self, empty):
         snap = empty
-        result = reduce(snap, {"t": "entity.create", "id": "guests", "p": {}})
+        result = apply(snap, {"t": "entity.create", "id": "guests", "p": {}})
         snap = result.snapshot
         for i in range(3):
-            result = reduce(snap, {"t": "entity.create", "id": f"guest_{i}", "parent": "guests", "p": {}})
+            result = apply(snap, {"t": "entity.create", "id": f"guest_{i}", "parent": "guests", "p": {}})
             snap = result.snapshot
 
-        result = reduce(
+        result = apply(
             snap,
             {
                 "t": "meta.constrain",
@@ -255,14 +255,14 @@ class TestMetaConstrain:
         assert result.accepted  # Non-strict: accepted even with violation
 
     def test_reject_missing_id(self, empty):
-        result = reduce(empty, {"t": "meta.constrain", "rule": "max_children"})
+        result = apply(empty, {"t": "meta.constrain", "rule": "max_children"})
         assert not result.accepted
         assert "MISSING_ID" in result.reason
 
     def test_updates_existing_constraint(self, empty):
-        result = reduce(empty, {"t": "meta.constrain", "id": "c1", "rule": "max_children", "value": 10})
+        result = apply(empty, {"t": "meta.constrain", "id": "c1", "rule": "max_children", "value": 10})
         snap = result.snapshot
-        result = reduce(snap, {"t": "meta.constrain", "id": "c1", "rule": "max_children", "value": 20})
+        result = apply(snap, {"t": "meta.constrain", "id": "c1", "rule": "max_children", "value": 20})
         assert result.accepted
         assert result.snapshot["meta"]["constraints"]["c1"]["value"] == 20
         assert len(result.snapshot["meta"]["constraints"]) == 1
@@ -275,19 +275,19 @@ class TestMetaConstrain:
 
 class TestVoiceSignal:
     def test_voice_accepted_with_signal(self, empty):
-        result = reduce(empty, {"t": "voice", "text": "Guest list updated."})
+        result = apply(empty, {"t": "voice", "text": "Guest list updated."})
         assert result.accepted
         assert result.signal is not None
         assert result.signal["type"] == "voice"
         assert result.signal["text"] == "Guest list updated."
 
     def test_voice_does_not_mutate_snapshot(self, empty):
-        result = reduce(empty, {"t": "voice", "text": "Something."})
+        result = apply(empty, {"t": "voice", "text": "Something."})
         assert result.accepted
         assert result.snapshot["_sequence"] == 0  # No mutation
 
     def test_voice_empty_text(self, empty):
-        result = reduce(empty, {"t": "voice", "text": ""})
+        result = apply(empty, {"t": "voice", "text": ""})
         assert result.accepted
         assert result.signal["text"] == ""
 
@@ -299,7 +299,7 @@ class TestVoiceSignal:
 
 class TestEscalateSignal:
     def test_escalate_accepted_with_signal(self, empty):
-        result = reduce(
+        result = apply(
             empty,
             {"t": "escalate", "tier": "L3", "reason": "structural_change", "extract": "Needs schema design."},
         )
@@ -311,7 +311,7 @@ class TestEscalateSignal:
         assert result.signal["extract"] == "Needs schema design."
 
     def test_escalate_does_not_mutate_snapshot(self, empty):
-        result = reduce(empty, {"t": "escalate", "tier": "L3", "reason": "x"})
+        result = apply(empty, {"t": "escalate", "tier": "L3", "reason": "x"})
         assert result.accepted
         assert result.snapshot["_sequence"] == 0
 
@@ -323,19 +323,19 @@ class TestEscalateSignal:
 
 class TestBatchSignals:
     def test_batch_start_accepted_with_signal(self, empty):
-        result = reduce(empty, {"t": "batch.start"})
+        result = apply(empty, {"t": "batch.start"})
         assert result.accepted
         assert result.signal["type"] == "batch.start"
 
     def test_batch_end_accepted_with_signal(self, empty):
-        result = reduce(empty, {"t": "batch.end"})
+        result = apply(empty, {"t": "batch.end"})
         assert result.accepted
         assert result.signal["type"] == "batch.end"
 
     def test_batch_signals_do_not_mutate_snapshot(self, empty):
-        result = reduce(empty, {"t": "batch.start"})
+        result = apply(empty, {"t": "batch.start"})
         assert result.snapshot["_sequence"] == 0
-        result2 = reduce(result.snapshot, {"t": "batch.end"})
+        result2 = apply(result.snapshot, {"t": "batch.end"})
         assert result2.snapshot["_sequence"] == 0
 
 
@@ -346,11 +346,11 @@ class TestBatchSignals:
 
 class TestUnknownPrimitive:
     def test_unknown_type_rejected(self, empty):
-        result = reduce(empty, {"t": "collection.create", "id": "test"})
+        result = apply(empty, {"t": "collection.create", "id": "test"})
         assert not result.accepted
         assert "UNKNOWN_PRIMITIVE" in result.reason
 
     def test_missing_type_rejected(self, empty):
-        result = reduce(empty, {"id": "test"})
+        result = apply(empty, {"id": "test"})
         assert not result.accepted
         assert "MISSING_TYPE" in result.reason


### PR DESCRIPTION
## Summary

- Rename `reducer.py` → `kernel.py` (the kernel IS the reducer)
- Rename `reduce()` → `apply()`, `reduce_all()` → `apply_all()`
- Rename `ReduceResult` → `ApplyResult`
- Update all imports across backend and tests
- Flatten test directory: `tests_reducer/` → `tests/`
- Rename test files: `test_reducer_*` → `test_*`

## TDD Approach

1. **RED**: Wrote test importing `apply` from `engine.kernel` (failed)
2. **GREEN**: Renamed files and functions, test passed
3. **REFACTOR**: Updated all imports across codebase

## Test plan

- [x] New `test_kernel_api.py` passes
- [x] All entity/relationship/style tests updated and passing
- [ ] CI passes

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)
