### PR TITLE
fix: address PR #172 review feedback

### DIFF
--- a/backend/routes/auth_routes.py
+++ b/backend/routes/auth_routes.py
@@ -82,7 +82,7 @@ async def send_magic_link_endpoint(
     return SendMagicLinkResponse()
 
 
-@router.get("/verify", status_code=302)
+@router.get("/verify", status_code=303)
 async def verify_magic_link_endpoint(
     token: str,
     request: Request,

--- a/frontend/src/components/__tests__/App.test.jsx
+++ b/frontend/src/components/__tests__/App.test.jsx
@@ -37,7 +37,6 @@ describe('App', () => {
       isLoading: false,
       user: null,
       sendMagicLink: vi.fn(),
-      verifyToken: vi.fn(),
       logout: vi.fn(),
     });
 
@@ -53,7 +52,6 @@ describe('App', () => {
       isLoading: true,
       user: null,
       sendMagicLink: vi.fn(),
-      verifyToken: vi.fn(),
       logout: vi.fn(),
     });
 
@@ -69,7 +67,6 @@ describe('App', () => {
       isLoading: false,
       user: { id: 'user-1', email: 'test@example.com' },
       sendMagicLink: vi.fn(),
-      verifyToken: vi.fn(),
       logout: vi.fn(),
     });
 
@@ -88,7 +85,6 @@ describe('App', () => {
       isLoading: false,
       user: { id: 'user-1', email: 'test@example.com' },
       sendMagicLink: vi.fn(),
-      verifyToken: vi.fn(),
       logout: vi.fn(),
     });
 
@@ -107,7 +103,6 @@ describe('App', () => {
       isLoading: false,
       user: { id: 'user-1', email: 'test@example.com' },
       sendMagicLink: vi.fn(),
-      verifyToken: vi.fn(),
       logout: vi.fn(),
     });
 

--- a/frontend/src/components/__tests__/AuthScreen.test.jsx
+++ b/frontend/src/components/__tests__/AuthScreen.test.jsx
@@ -28,13 +28,12 @@ vi.mock('react-router-dom', async () => {
 describe('AuthScreen', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockSearchParams.delete('token');
+    mockSearchParams.delete('error');
   });
 
   it('renders email input and send button', () => {
     vi.spyOn(useAuthModule, 'useAuth').mockReturnValue({
       sendMagicLink: vi.fn(),
-      verifyToken: vi.fn(),
     });
 
     render(
@@ -51,7 +50,6 @@ describe('AuthScreen', () => {
     const mockSendMagicLink = vi.fn().mockResolvedValue({ data: {} });
     vi.spyOn(useAuthModule, 'useAuth').mockReturnValue({
       sendMagicLink: mockSendMagicLink,
-      verifyToken: vi.fn(),
     });
 
     render(
@@ -75,7 +73,6 @@ describe('AuthScreen', () => {
     const mockSendMagicLink = vi.fn().mockResolvedValue({ data: {} });
     vi.spyOn(useAuthModule, 'useAuth').mockReturnValue({
       sendMagicLink: mockSendMagicLink,
-      verifyToken: vi.fn(),
     });
 
     render(
@@ -95,22 +92,78 @@ describe('AuthScreen', () => {
     });
   });
 
-  it('calls verifyToken on mount when token is in URL', async () => {
-    mockSearchParams.set('token', 'test-token-123');
-    const mockVerifyToken = vi.fn().mockResolvedValue({ data: {} });
+  it('displays error for invalid_link error param', () => {
+    mockSearchParams.set('error', 'invalid_link');
     vi.spyOn(useAuthModule, 'useAuth').mockReturnValue({
       sendMagicLink: vi.fn(),
-      verifyToken: mockVerifyToken,
     });
 
     render(
-      <MemoryRouter initialEntries={['/?token=test-token-123']}>
+      <MemoryRouter>
         <AuthScreen />
       </MemoryRouter>
     );
 
-    await waitFor(() => {
-      expect(mockVerifyToken).toHaveBeenCalledWith('test-token-123');
+    expect(screen.getByText(/invalid magic link/i)).toBeInTheDocument();
+  });
+
+  it('displays error for link_used error param', () => {
+    mockSearchParams.set('error', 'link_used');
+    vi.spyOn(useAuthModule, 'useAuth').mockReturnValue({
+      sendMagicLink: vi.fn(),
     });
+
+    render(
+      <MemoryRouter>
+        <AuthScreen />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/already been used/i)).toBeInTheDocument();
+  });
+
+  it('displays error for link_expired error param', () => {
+    mockSearchParams.set('error', 'link_expired');
+    vi.spyOn(useAuthModule, 'useAuth').mockReturnValue({
+      sendMagicLink: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <AuthScreen />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/expired/i)).toBeInTheDocument();
+  });
+
+  it('displays error for too_many_attempts error param', () => {
+    mockSearchParams.set('error', 'too_many_attempts');
+    vi.spyOn(useAuthModule, 'useAuth').mockReturnValue({
+      sendMagicLink: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <AuthScreen />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/too many/i)).toBeInTheDocument();
+  });
+
+  it('displays generic error for unknown error param', () => {
+    mockSearchParams.set('error', 'unknown_error');
+    vi.spyOn(useAuthModule, 'useAuth').mockReturnValue({
+      sendMagicLink: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <AuthScreen />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/authentication failed/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/hooks/__tests__/useAuth.test.js
+++ b/frontend/src/hooks/__tests__/useAuth.test.js
@@ -78,29 +78,6 @@ describe('useAuth', () => {
     expect(api.sendMagicLink).toHaveBeenCalledWith(email);
   });
 
-  it('verifyToken calls api.verifyToken, sets user and isAuthenticated on success', async () => {
-    const mockUser = { id: '2', email: 'verified@example.com' };
-    api.fetchMe.mockResolvedValue({ error: 'Not authenticated' });
-    api.verifyToken.mockResolvedValue({ data: mockUser });
-
-    const { result } = renderHook(() => useAuth(), {
-      wrapper: AuthProvider,
-    });
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
-
-    const token = 'test-token';
-    await act(async () => {
-      await result.current.verifyToken(token);
-    });
-
-    expect(api.verifyToken).toHaveBeenCalledWith(token);
-    expect(result.current.user).toEqual(mockUser);
-    expect(result.current.isAuthenticated).toBe(true);
-  });
-
   it('logout calls api.logout, sets user=null and isAuthenticated=false', async () => {
     const mockUser = { id: '1', email: 'a@b.com' };
     api.fetchMe.mockResolvedValue({ data: mockUser });

--- a/frontend/src/hooks/useAuth.jsx
+++ b/frontend/src/hooks/useAuth.jsx
@@ -33,17 +33,6 @@ export function AuthProvider({ children }) {
 
   const sendMagicLink = (email) => api.sendMagicLink(email);
 
-  const verifyToken = async (token) => {
-    const result = await api.verifyToken(token);
-
-    if (result.data) {
-      setUser(result.data);
-      setIsAuthenticated(true);
-    }
-
-    return result;
-  };
-
   const logout = async () => {
     await api.logout();
     setUser(null);
@@ -55,7 +44,6 @@ export function AuthProvider({ children }) {
     isAuthenticated,
     isLoading,
     sendMagicLink,
-    verifyToken,
     logout,
   };
 

--- a/frontend/src/lib/__tests__/api.test.js
+++ b/frontend/src/lib/__tests__/api.test.js
@@ -10,7 +10,6 @@ import {
   publishAide,
   unpublishAide,
   sendMagicLink,
-  verifyToken,
   fetchMe,
   logout,
 } from '../api.js';
@@ -193,22 +192,6 @@ describe('api', () => {
       credentials: 'same-origin',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email: 'a@b.com' }),
-    });
-    expect(result).toEqual({ data: mockData });
-  });
-
-  it("verifyToken('tok123') calls GET /auth/verify?token=tok123", async () => {
-    const mockData = { user_id: 'u1' };
-    global.fetch.mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => mockData,
-    });
-
-    const result = await verifyToken('tok123');
-
-    expect(global.fetch).toHaveBeenCalledWith('/auth/verify?token=tok123', {
-      credentials: 'same-origin',
     });
     expect(result).toEqual({ data: mockData });
   });

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -89,10 +89,6 @@ export async function sendMagicLink(email) {
   });
 }
 
-export async function verifyToken(token) {
-  return apiCall(`/auth/verify?token=${token}`);
-}
-
 export async function fetchMe() {
   return apiCall('/auth/me');
 }


### PR DESCRIPTION
## Summary
- Fix status code decorator (302 to 303) to match actual response
- Add frontend tests for error param handling
- Remove dead verifyToken code

## Changes
1. Backend: Fixed misleading status_code=302 decorator to 303
2. Frontend tests: Added 5 new tests for error param handling
3. Dead code removal: Removed verifyToken from useAuth.jsx, api.js, and all related tests

Targets: claude/issue-170 (PR #172)